### PR TITLE
fix: resolve RichTextEditor CommonJS require error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "react-bootstrap": "^2.10.10",
         "react-dom": "^19.1.1",
         "react-icons": "^5.5.0",
-        "react-quilljs": "^2.0.5",
         "react-redux": "^9.2.0",
         "react-router-dom": "^7.9.4",
         "react-select": "^5.10.2",
@@ -4464,17 +4463,6 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "license": "MIT"
-    },
-    "node_modules/react-quilljs": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/react-quilljs/-/react-quilljs-2.0.5.tgz",
-      "integrity": "sha512-92ngIpH5LyyG1oy6p9rX5vZNlbpPpIK7hMm8yrBuyhaEuA7k+pCj8omCIlEnSKsaXSX40KjD8jw2mAuj385C9Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "quill": "^2.0.3",
-        "react": "17 - 19",
-        "react-dom": "17 - 19"
-      }
     },
     "node_modules/react-redux": {
       "version": "9.2.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "react-bootstrap": "^2.10.10",
     "react-dom": "^19.1.1",
     "react-icons": "^5.5.0",
-    "react-quilljs": "^2.0.5",
     "react-redux": "^9.2.0",
     "react-router-dom": "^7.9.4",
     "react-select": "^5.10.2",

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  optimizeDeps: {
+    include: ['quill']
+  },
   build: {
     rollupOptions: {
       output: {


### PR DESCRIPTION
Replaced react-quilljs wrapper with direct Quill integration to fix "require is not defined" error in browser. The react-quilljs library was using CommonJS syntax incompatible with Vite's ES module system.

Changes:
- Removed react-quilljs dependency
- Implemented custom Quill initialization using React hooks
- Updated Vite config to optimize Quill dependency
- Maintains all existing editor features and functionality
