### PR TITLE
fix: remove invalid 'bullet' format from Quill configuration

### DIFF
--- a/src/components/ui/RichTextEditor.jsx
+++ b/src/components/ui/RichTextEditor.jsx
@@ -48,7 +48,7 @@ const RichTextEditor = ({
   const formats = [
     'header',
     'bold', 'italic', 'underline', 'strike',
-    'list', 'bullet',
+    'list',
     'align',
     'link',
     'blockquote', 'code-block'


### PR DESCRIPTION
- Remove 'bullet' from formats array in RichTextEditor
- 'list' format handles both ordered and bullet lists
- Fixes Quill console warning about unregistered 'bullet' format