### PR TITLE
feat: convert CRUD modals to page-based add/edit forms

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -46,6 +46,15 @@
   //     ]
   //   },
   // ]
-  "indexes": [],
+  "indexes": [
+    {
+      "collectionGroup": "notifications",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "recipientId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    }
+  ],
   "fieldOverrides": []
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -22,9 +22,9 @@ service cloud.firestore {
       return isAuthenticated() && getUserRole() == 'maintainer';
     }
 
-    // Helper function to check if user is admin (superadmin or maintainer)
+    // Helper function to check if user is admin (superadmin, admin, or maintainer)
     function isAdmin() {
-      return isSuperAdmin() || isMaintainer();
+      return isSuperAdmin() || isMaintainer() || (isAuthenticated() && getUserRole() == 'admin');
     }
 
     // Users collection
@@ -79,6 +79,13 @@ service cloud.firestore {
       allow read: if isSuperAdmin();
       // No one can update or delete activities (audit trail)
       allow update, delete: if false;
+    }
+
+    // Notifications collection - users can read their own, authenticated can create
+    match /notifications/{notificationId} {
+      allow read: if isAuthenticated() && resource.data.recipientId == request.auth.uid;
+      allow create: if isAuthenticated();
+      allow update: if isAuthenticated() && resource.data.recipientId == request.auth.uid;
     }
 
     // Deny all other access

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,8 +18,11 @@ const Patients = lazy(() => import('./pages/Patients'))
 const PatientDetail = lazy(() => import('./pages/PatientDetail'))
 const Checkups = lazy(() => import('./pages/Checkups'))
 const CheckupDetail = lazy(() => import('./pages/CheckupDetail'))
+const CheckupForm = lazy(() => import('./pages/CheckupForm'))
 const Tests = lazy(() => import('./pages/Tests'))
+const TestDetail = lazy(() => import('./pages/TestDetail'))
 const Medicines = lazy(() => import('./pages/Medicines'))
+const MedicineDetail = lazy(() => import('./pages/MedicineDetail'))
 const UserManagement = lazy(() => import('./pages/UserManagement'))
 const AdminSetup = lazy(() => import('./pages/AdminSetup'))
 
@@ -127,6 +130,22 @@ function AppContent() {
                 }
               />
               <Route
+                path="/checkups/new"
+                element={
+                  <ProtectedRoute>
+                    <CheckupForm />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/checkups/:id/edit"
+                element={
+                  <ProtectedRoute>
+                    <CheckupForm />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
                 path="/checkups/:id"
                 element={
                   <ProtectedRoute>
@@ -143,10 +162,26 @@ function AppContent() {
                 }
               />
               <Route
+                path="/tests/:id"
+                element={
+                  <ProtectedRoute>
+                    <TestDetail />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
                 path="/medicines"
                 element={
                   <ProtectedRoute>
                     <Medicines />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/medicines/:id"
+                element={
+                  <ProtectedRoute>
+                    <MedicineDetail />
                   </ProtectedRoute>
                 }
               />

--- a/src/components/crud/EntityForm.jsx
+++ b/src/components/crud/EntityForm.jsx
@@ -1,0 +1,181 @@
+import React from 'react';
+import { Card, Button, Form, Row, Col, Spinner } from 'react-bootstrap';
+import { FaArrowLeft, FaSave, FaTrash } from 'react-icons/fa';
+import FormField from '../ui/FormField';
+import RichTextEditor from '../ui/RichTextEditor';
+
+const EntityForm = React.memo(({
+  title,
+  fields = [],
+  formData = {},
+  formErrors = {},
+  onFormChange,
+  onSubmit,
+  onCancel,
+  onDelete,
+  loading = false,
+  isEditing = false,
+  children,
+}) => {
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSubmit(e);
+  };
+
+  return (
+    <Card className="shadow-sm">
+      <Card.Header
+        style={{
+          background: 'linear-gradient(135deg, #0891B2, #06B6D4)',
+          color: 'white',
+          padding: '0.75rem 1.25rem',
+        }}
+      >
+        <h5 className="mb-0" style={{ fontSize: 'clamp(0.95rem, 2.5vw, 1.25rem)' }}>{title}</h5>
+      </Card.Header>
+
+      <Form onSubmit={handleSubmit}>
+        <Card.Body className="entity-form-body">
+          {children || (
+            <Row className="g-3">
+              {fields.map((field) => (
+                <Col
+                  key={field.name}
+                  xs={12}
+                  md={field.colSize || 6}
+                >
+                  {field.type === 'richtext' ? (
+                    <RichTextEditor
+                      label={field.label}
+                      value={formData[field.name] || ''}
+                      onChange={(value) => onFormChange({ target: { name: field.name, value } })}
+                      error={formErrors[field.name]}
+                      required={field.required}
+                      placeholder={field.placeholder}
+                      height={field.height || '200px'}
+                      id={field.name}
+                    />
+                  ) : (
+                    <FormField
+                      label={field.label}
+                      name={field.name}
+                      type={field.type || 'text'}
+                      value={formData[field.name] || ''}
+                      onChange={onFormChange}
+                      error={formErrors[field.name]}
+                      required={field.required}
+                      placeholder={field.placeholder}
+                      options={field.options}
+                      disabled={loading || field.disabled}
+                      rows={field.rows}
+                      {...(field.props || {})}
+                    />
+                  )}
+                </Col>
+              ))}
+            </Row>
+          )}
+
+          {formErrors.submit && (
+            <div className="text-danger mt-2">{formErrors.submit}</div>
+          )}
+        </Card.Body>
+
+        <Card.Footer className="entity-form-footer">
+          <Button
+            variant="outline-secondary"
+            onClick={onCancel}
+            disabled={loading}
+            className="entity-form-btn"
+          >
+            <FaArrowLeft className="me-1" />
+            Back
+          </Button>
+
+          <div className="entity-form-actions">
+            {isEditing && onDelete && (
+              <Button
+                variant="outline-danger"
+                onClick={onDelete}
+                disabled={loading}
+                className="entity-form-btn"
+              >
+                <FaTrash className="me-1" />
+                Delete
+              </Button>
+            )}
+            <Button
+              type="submit"
+              disabled={loading}
+              className="entity-form-btn"
+              style={{
+                backgroundColor: '#06B6D4',
+                border: 'none',
+                color: 'white',
+              }}
+            >
+              {loading ? (
+                <>
+                  <Spinner size="sm" className="me-1" />
+                  Saving...
+                </>
+              ) : (
+                <>
+                  <FaSave className="me-1" />
+                  {isEditing ? 'Update' : 'Save'}
+                </>
+              )}
+            </Button>
+          </div>
+
+          <style>{`
+            .entity-form-body {
+              padding: 1.25rem;
+            }
+            .entity-form-footer {
+              display: flex;
+              flex-wrap: wrap;
+              gap: 0.5rem;
+              justify-content: space-between;
+              align-items: center;
+              padding: 0.75rem 1.25rem;
+            }
+            .entity-form-actions {
+              display: flex;
+              gap: 0.5rem;
+              flex-wrap: wrap;
+            }
+            .entity-form-btn {
+              min-width: 100px;
+              min-height: 44px;
+            }
+
+            @media (max-width: 767px) {
+              .entity-form-body {
+                padding: 0.75rem;
+              }
+              .entity-form-footer {
+                flex-direction: column;
+                gap: 0.5rem;
+                padding: 0.75rem;
+              }
+              .entity-form-actions {
+                width: 100%;
+                flex-direction: column;
+              }
+              .entity-form-btn {
+                width: 100%;
+                min-height: 48px;
+                font-size: 1rem;
+              }
+            }
+          `}</style>
+        </Card.Footer>
+      </Form>
+    </Card>
+  );
+});
+
+EntityForm.displayName = 'EntityForm';
+
+export default EntityForm;

--- a/src/components/crud/index.js
+++ b/src/components/crud/index.js
@@ -2,3 +2,4 @@
 export { default as CRUDTable } from './CRUDTable';
 export { default as EnhancedCRUDTable } from './EnhancedCRUDTable';
 export { default as CRUDModal } from './CRUDModal';
+export { default as EntityForm } from './EntityForm';

--- a/src/components/ui/FormField.jsx
+++ b/src/components/ui/FormField.jsx
@@ -135,7 +135,7 @@ const FormField = React.memo(({
 
   if (type === 'checkbox' || type === 'radio') {
     return (
-      <Form.Group className="mb-3">
+      <Form.Group className="mb-3" controlId={name}>
         {type === 'radio' && label && (
           <Form.Label>
             {label}
@@ -149,7 +149,7 @@ const FormField = React.memo(({
   }
 
   return (
-    <Form.Group className="mb-3">
+    <Form.Group className="mb-3" controlId={name}>
       {label && (
         <Form.Label>
           {label}

--- a/src/hooks/useForm.js
+++ b/src/hooks/useForm.js
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 
 /**
  * Custom hook for managing form state and validation
@@ -8,6 +8,12 @@ export const useForm = (initialValues = {}, onSubmit, validate) => {
   const [formData, setFormData] = useState(initialValues);
   const [errors, setErrors] = useState({});
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Keep a ref to always have the latest formData in handleSubmit
+  const formDataRef = useRef(formData);
+  useEffect(() => {
+    formDataRef.current = formData;
+  }, [formData]);
 
   // Handle individual field change
   const handleChange = useCallback((e) => {
@@ -51,9 +57,12 @@ export const useForm = (initialValues = {}, onSubmit, validate) => {
     async (e) => {
       if (e) e.preventDefault();
 
+      // Use ref to get latest formData (avoids stale closure from onBlur race)
+      const currentData = formDataRef.current;
+
       // Validate if validation function provided
       if (validate) {
-        const validationErrors = validate(formData);
+        const validationErrors = validate(currentData);
         if (Object.keys(validationErrors).length > 0) {
           setErrors(validationErrors);
           return false;
@@ -64,7 +73,7 @@ export const useForm = (initialValues = {}, onSubmit, validate) => {
       setErrors({});
 
       try {
-        await onSubmit(formData);
+        await onSubmit(currentData);
         return true;
       } catch (error) {
         setErrors({ submit: error.message || 'Submission failed' });
@@ -73,7 +82,7 @@ export const useForm = (initialValues = {}, onSubmit, validate) => {
         setIsSubmitting(false);
       }
     },
-    [formData, onSubmit, validate]
+    [onSubmit, validate]
   );
 
   return {

--- a/src/pages/CheckupDetail.jsx
+++ b/src/pages/CheckupDetail.jsx
@@ -4,7 +4,7 @@ import { useSelector, useDispatch } from 'react-redux'
 import { Container, Row, Col, Card, Button, Table, Form, Collapse, Tabs, Tab } from 'react-bootstrap'
 import { FaArrowLeft, FaFilePdf, FaPrint, FaWhatsapp, FaFacebook, FaInstagram, FaEnvelope, FaPhone, FaEdit, FaSave, FaTimes, FaCog, FaStickyNote, FaPrescriptionBottleAlt, FaPlus, FaTrash } from 'react-icons/fa'
 import Select from 'react-select'
-import { selectAllCheckups, updateCheckup } from '../store/checkupsSlice'
+import { selectAllCheckups, updateCheckup, deleteCheckup } from '../store/checkupsSlice'
 import { selectAllPatients } from '../store/patientsSlice'
 import { selectAllTests } from '../store/testsSlice'
 import { selectAllMedicines, fetchMedicines } from '../store/medicinesSlice'
@@ -125,6 +125,17 @@ function CheckupDetail() {
     } catch (error) {
       console.error('Error updating checkup:', error)
       alert('Failed to update checkup')
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!window.confirm('Are you sure you want to delete this checkup?')) return
+    try {
+      await dispatch(deleteCheckup(id)).unwrap()
+      navigate('/checkups')
+    } catch (error) {
+      console.error('Error deleting checkup:', error)
+      alert('Failed to delete checkup')
     }
   }
 
@@ -1342,12 +1353,12 @@ function CheckupDetail() {
                                   <Select
                                     value={selectedMedicine ? {
                                       value: selectedMedicine.id,
-                                      label: `${selectedMedicine.name} - ${selectedMedicine.dosage} - ${selectedMedicine.brand}`
+                                      label: `${selectedMedicine.name} - ${Array.isArray(selectedMedicine.dosage) ? selectedMedicine.dosage.join(', ') : selectedMedicine.dosage} - ${selectedMedicine.brand}`
                                     } : null}
                                     onChange={(option) => handleMedicineChange(index, 'medicineId', option.value)}
                                     options={medicines.map(m => ({
                                       value: m.id,
-                                      label: `${m.name} - ${m.dosage} - ${m.brand}`
+                                      label: `${m.name} - ${Array.isArray(m.dosage) ? m.dosage.join(', ') : m.dosage} - ${m.brand}`
                                     }))}
                                     placeholder="Select medicine with dosage..."
                                     styles={{
@@ -1482,7 +1493,7 @@ function CheckupDetail() {
                                   <br />
                                   <span style={{ fontSize: '0.75rem', color: '#64748b' }}>{medicine.brand}</span>
                                 </td>
-                                <td style={{ padding: '0.5rem', fontWeight: '600', color: '#059669' }}>{medicine.dosage || '-'}</td>
+                                <td style={{ padding: '0.5rem', fontWeight: '600', color: '#059669' }}>{Array.isArray(medicine.dosage) ? medicine.dosage.join(', ') : (medicine.dosage || '-')}</td>
                                 <td style={{ padding: '0.5rem' }}>{med.quantity ? `${med.quantity} ${medicine.unit}` : '-'}</td>
                                 <td style={{ padding: '0.5rem' }}>{med.instructions || '-'}</td>
                               </tr>
@@ -1608,6 +1619,42 @@ function CheckupDetail() {
             }
           `}</style>
         </>
+      )}
+
+      {/* Edit & Delete Buttons at Bottom */}
+      {!isEditing && (
+        <Row className="mt-4 no-print">
+          <Col>
+            <Card>
+              <Card.Body className="d-flex gap-2 flex-wrap justify-content-end">
+                <Button
+                  onClick={() => navigate(`/checkups/${id}/edit`)}
+                  style={{
+                    backgroundColor: '#06B6D4',
+                    border: 'none',
+                    color: 'white',
+                    padding: '0.5rem 1.5rem',
+                  }}
+                >
+                  <FaEdit className="me-2" />
+                  Edit Checkup
+                </Button>
+                <Button
+                  onClick={handleDelete}
+                  style={{
+                    backgroundColor: '#ef4444',
+                    border: 'none',
+                    color: 'white',
+                    padding: '0.5rem 1.5rem',
+                  }}
+                >
+                  <FaTrash className="me-2" />
+                  Delete Checkup
+                </Button>
+              </Card.Body>
+            </Card>
+          </Col>
+        </Row>
       )}
     </Container>
   )

--- a/src/pages/CheckupForm.jsx
+++ b/src/pages/CheckupForm.jsx
@@ -1,0 +1,579 @@
+import { useState, useEffect, useCallback } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { useDispatch, useSelector } from 'react-redux'
+import { Container, Row, Col, Card, Button, Form, Badge } from 'react-bootstrap'
+import { FaClipboardCheck, FaArrowLeft, FaSave, FaTrash, FaPlus } from 'react-icons/fa'
+import Select from 'react-select'
+import { fetchCheckups, addCheckup, updateCheckup, deleteCheckup, selectAllCheckups } from '../store/checkupsSlice'
+import { fetchPatients, addPatient, selectAllPatients } from '../store/patientsSlice'
+import { fetchTests, selectAllTests } from '../store/testsSlice'
+import { useNotification } from '../context'
+import { usePermission } from '../components/auth/PermissionGate'
+import LoadingSpinner from '../components/common/LoadingSpinner'
+
+function CheckupForm() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const dispatch = useDispatch()
+  const { success, error: showError } = useNotification()
+  const { checkPermission } = usePermission()
+
+  const checkups = useSelector(selectAllCheckups)
+  const patients = useSelector(selectAllPatients)
+  const tests = useSelector(selectAllTests)
+  const { loading: checkupsLoading } = useSelector(state => state.checkups)
+  const { loading: patientsLoading } = useSelector(state => state.patients)
+  const { loading: testsLoading } = useSelector(state => state.tests)
+
+  const isNew = !id
+  const checkup = isNew ? null : checkups.find(c => c.id === id)
+  const loading = checkupsLoading || patientsLoading || testsLoading
+
+  const [formData, setFormData] = useState({
+    patientId: '',
+    tests: [],
+    weight: '',
+    height: ''
+  })
+  const [showNewPatientForm, setShowNewPatientForm] = useState(false)
+  const [newPatientData, setNewPatientData] = useState({
+    name: '',
+    age: '',
+    gender: 'Male',
+    mobile: '',
+    email: '',
+    address: ''
+  })
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  // Fetch data if store is empty
+  useEffect(() => {
+    if (checkups.length === 0) dispatch(fetchCheckups())
+    if (patients.length === 0) dispatch(fetchPatients())
+    if (tests.length === 0) dispatch(fetchTests())
+  }, [dispatch, checkups.length, patients.length, tests.length])
+
+  // Load checkup data into form when editing
+  useEffect(() => {
+    if (checkup) {
+      setFormData({
+        patientId: checkup.patientId || '',
+        tests: checkup.tests || [],
+        weight: checkup.weight || '',
+        height: checkup.height || ''
+      })
+    }
+  }, [checkup?.id]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handlePatientSelect = (selectedOption) => {
+    if (selectedOption) {
+      setFormData(prev => ({ ...prev, patientId: selectedOption.value }))
+      setShowNewPatientForm(false)
+    } else {
+      setFormData(prev => ({ ...prev, patientId: '' }))
+    }
+  }
+
+  const handleCreateNewPatient = async () => {
+    try {
+      const result = await dispatch(addPatient(newPatientData))
+      if (result.payload?.id) {
+        setFormData(prev => ({ ...prev, patientId: result.payload.id }))
+        setShowNewPatientForm(false)
+        setNewPatientData({ name: '', age: '', gender: 'Male', mobile: '', email: '', address: '' })
+        success('Patient created successfully!')
+      }
+    } catch (err) {
+      showError(err.message || 'Error creating patient')
+    }
+  }
+
+  const handleTestChange = (selectedOptions) => {
+    const newTests = selectedOptions ? selectedOptions.map(option => ({
+      testId: option.value
+    })) : []
+    setFormData(prev => ({ ...prev, tests: newTests }))
+  }
+
+  const calculateTotal = useCallback(() => {
+    return formData.tests.reduce((sum, testItem) => {
+      const test = tests.find(t => t.id === testItem.testId)
+      return sum + (test?.price || 0)
+    }, 0)
+  }, [formData.tests, tests])
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+
+    if (!formData.patientId) {
+      showError('Please select a patient')
+      return
+    }
+
+    if (formData.tests.length === 0) {
+      showError('Please select at least one test')
+      return
+    }
+
+    setIsSubmitting(true)
+
+    const checkupData = {
+      ...formData,
+      total: calculateTotal()
+    }
+
+    try {
+      if (isNew) {
+        const result = await dispatch(addCheckup(checkupData))
+        if (result.type.includes('rejected')) {
+          throw new Error(result.payload || 'Failed to create checkup')
+        }
+        success('Checkup created successfully!')
+        navigate(`/checkups/${result.payload.id}`, { replace: true })
+      } else {
+        const result = await dispatch(updateCheckup({
+          id,
+          ...checkupData,
+          timestamp: checkup.timestamp
+        }))
+        if (result.type.includes('rejected')) {
+          throw new Error(result.payload || 'Failed to update checkup')
+        }
+        success('Checkup updated successfully!')
+        navigate(`/checkups/${id}`)
+      }
+    } catch (err) {
+      showError(err.message || 'Operation failed')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!window.confirm('Are you sure you want to delete this checkup?')) return
+    try {
+      const result = await dispatch(deleteCheckup(id))
+      if (result.type.includes('rejected')) {
+        throw new Error(result.payload || 'Failed to delete checkup')
+      }
+      success('Checkup deleted successfully!')
+      navigate('/checkups')
+    } catch (err) {
+      showError(err.message || 'Delete failed')
+    }
+  }
+
+  // Loading state
+  if (loading && checkups.length === 0) {
+    return <LoadingSpinner text="Loading data..." />
+  }
+
+  // Not found
+  if (!isNew && !checkup && checkups.length > 0) {
+    return (
+      <Container fluid className="p-3 p-md-4">
+        <Card>
+          <Card.Body className="text-center py-5">
+            <h4>Checkup not found</h4>
+            <Button
+              onClick={() => navigate('/checkups')}
+              style={{ backgroundColor: '#06B6D4', border: 'none', color: 'white' }}
+            >
+              <FaArrowLeft className="me-2" />
+              Back to Checkups
+            </Button>
+          </Card.Body>
+        </Card>
+      </Container>
+    )
+  }
+
+  const patient = patients.find(p => p.id === formData.patientId)
+  const canDelete = !isNew && checkPermission('checkups', 'delete')
+
+  // react-select styles for test multi-select
+  const testSelectStyles = {
+    control: (base) => ({
+      ...base,
+      minHeight: '38px',
+      fontSize: '14px'
+    }),
+    valueContainer: (base) => ({
+      ...base,
+      padding: '2px 8px',
+      gap: '3px'
+    }),
+    multiValue: (base) => ({
+      ...base,
+      backgroundColor: '#0dcaf0',
+      borderRadius: '3px',
+      margin: '2px'
+    }),
+    multiValueLabel: (base) => ({
+      ...base,
+      color: 'white',
+      fontSize: '13px',
+      padding: '2px 8px'
+    }),
+    multiValueRemove: (base) => ({
+      ...base,
+      color: 'white',
+      padding: '2px 4px',
+      ':hover': {
+        backgroundColor: '#0aa2c0',
+        color: 'white'
+      }
+    }),
+    option: (base) => ({
+      ...base,
+      padding: '8px 12px'
+    }),
+    menu: (base) => ({
+      ...base,
+      fontSize: '14px'
+    }),
+    placeholder: (base) => ({
+      ...base,
+      fontSize: '14px'
+    })
+  }
+
+  return (
+    <Container fluid className="p-3 p-md-4">
+      <Row className="mb-4">
+        <Col>
+          <h2 style={{ fontSize: 'clamp(1.2rem, 3vw, 1.75rem)' }}>
+            <FaClipboardCheck className="me-2" style={{ color: '#0891B2' }} />
+            {isNew ? 'New Checkup / Bill' : 'Edit Checkup'}
+          </h2>
+        </Col>
+      </Row>
+
+      <Row>
+        <Col>
+          <Card className="shadow-sm">
+            <Card.Header
+              style={{
+                background: 'linear-gradient(135deg, #0891B2, #06B6D4)',
+                color: 'white',
+                padding: '0.75rem 1.25rem',
+              }}
+            >
+              <h5 className="mb-0" style={{ fontSize: 'clamp(0.95rem, 2.5vw, 1.25rem)' }}>
+                {isNew ? 'Checkup Information' : `Edit Checkup: ${checkup?.billNo || checkup?.id || ''}`}
+              </h5>
+            </Card.Header>
+
+            <Form onSubmit={handleSubmit}>
+              <Card.Body className="entity-form-body">
+                {/* Patient Selection Section */}
+                <h6 style={{ color: '#0891B2', borderBottom: '2px solid #e0f2fe', paddingBottom: '0.5rem', marginBottom: '1rem' }}>
+                  Patient
+                </h6>
+
+                <Form.Group className="mb-3">
+                  <Form.Label>Select Patient *</Form.Label>
+                  <Select
+                    options={patients.map(p => ({
+                      value: p.id,
+                      label: `${p.name} - ${p.age}yr - ${p.mobile}`,
+                      patient: p
+                    }))}
+                    value={patients
+                      .filter(p => p.id === formData.patientId)
+                      .map(p => ({
+                        value: p.id,
+                        label: `${p.name} - ${p.age}yr - ${p.mobile}`
+                      }))[0] || null}
+                    onChange={handlePatientSelect}
+                    placeholder="Search patient by name, mobile..."
+                    isClearable
+                    formatOptionLabel={(option) => (
+                      <div>
+                        <div><strong>{option.patient?.name || option.label.split(' - ')[0]}</strong></div>
+                        <small className="text-muted">
+                          {option.patient?.age}yr, {option.patient?.gender} - {option.patient?.mobile}
+                        </small>
+                      </div>
+                    )}
+                  />
+                </Form.Group>
+
+                <div className="text-center mb-3">
+                  <Button
+                    variant="link"
+                    onClick={() => setShowNewPatientForm(!showNewPatientForm)}
+                  >
+                    {showNewPatientForm ? 'Cancel' : '+ Add New Patient'}
+                  </Button>
+                </div>
+
+                {showNewPatientForm && (
+                  <Card className="mb-3">
+                    <Card.Header className="bg-light">
+                      <strong>New Patient Information</strong>
+                    </Card.Header>
+                    <Card.Body>
+                      <Row>
+                        <Col md={6}>
+                          <Form.Group className="mb-3">
+                            <Form.Label>Name *</Form.Label>
+                            <Form.Control
+                              type="text"
+                              value={newPatientData.name}
+                              onChange={(e) => setNewPatientData({ ...newPatientData, name: e.target.value })}
+                              required
+                            />
+                          </Form.Group>
+                        </Col>
+                        <Col md={3}>
+                          <Form.Group className="mb-3">
+                            <Form.Label>Age *</Form.Label>
+                            <Form.Control
+                              type="number"
+                              value={newPatientData.age}
+                              onChange={(e) => setNewPatientData({ ...newPatientData, age: e.target.value })}
+                              required
+                            />
+                          </Form.Group>
+                        </Col>
+                        <Col md={3}>
+                          <Form.Group className="mb-3">
+                            <Form.Label>Gender *</Form.Label>
+                            <Form.Select
+                              value={newPatientData.gender}
+                              onChange={(e) => setNewPatientData({ ...newPatientData, gender: e.target.value })}
+                            >
+                              <option>Male</option>
+                              <option>Female</option>
+                              <option>Other</option>
+                            </Form.Select>
+                          </Form.Group>
+                        </Col>
+                        <Col md={6}>
+                          <Form.Group className="mb-3">
+                            <Form.Label>Mobile *</Form.Label>
+                            <Form.Control
+                              type="tel"
+                              value={newPatientData.mobile}
+                              onChange={(e) => setNewPatientData({ ...newPatientData, mobile: e.target.value })}
+                              required
+                            />
+                          </Form.Group>
+                        </Col>
+                        <Col md={6}>
+                          <Form.Group className="mb-3">
+                            <Form.Label>Email</Form.Label>
+                            <Form.Control
+                              type="email"
+                              value={newPatientData.email}
+                              onChange={(e) => setNewPatientData({ ...newPatientData, email: e.target.value })}
+                            />
+                          </Form.Group>
+                        </Col>
+                        <Col md={12}>
+                          <Form.Group className="mb-3">
+                            <Form.Label>Address *</Form.Label>
+                            <Form.Control
+                              as="textarea"
+                              rows={2}
+                              value={newPatientData.address}
+                              onChange={(e) => setNewPatientData({ ...newPatientData, address: e.target.value })}
+                              required
+                            />
+                          </Form.Group>
+                        </Col>
+                      </Row>
+                      <Button variant="primary" onClick={handleCreateNewPatient} size="sm">
+                        <FaPlus className="me-1" />
+                        Create Patient & Continue
+                      </Button>
+                    </Card.Body>
+                  </Card>
+                )}
+
+                {/* Tests Selection Section */}
+                <h6 style={{ color: '#0891B2', borderBottom: '2px solid #e0f2fe', paddingBottom: '0.5rem', marginBottom: '1rem', marginTop: '1.5rem' }}>
+                  Tests
+                </h6>
+
+                <Form.Group className="mb-3">
+                  <Form.Label>Select Tests *</Form.Label>
+                  <Select
+                    isMulti
+                    options={tests.map(test => ({
+                      value: test.id,
+                      label: test.name,
+                      code: test.code,
+                      price: test.price,
+                      details: test.details
+                    }))}
+                    value={tests
+                      .filter(test => formData.tests.some(t => t.testId === test.id))
+                      .map(test => ({
+                        value: test.id,
+                        label: test.name,
+                        code: test.code
+                      }))}
+                    onChange={handleTestChange}
+                    isDisabled={loading}
+                    placeholder="Search tests by name or code..."
+                    formatOptionLabel={(option, { context }) => {
+                      if (context === 'value') {
+                        return (
+                          <span>
+                            <strong style={{ color: '#0891B2' }}>{option.code}</strong> - {option.label}
+                          </span>
+                        )
+                      }
+                      return (
+                        <div className="d-flex justify-content-between align-items-center">
+                          <div>
+                            <div style={{ fontSize: '14px' }}>
+                              <strong style={{ color: '#0891B2' }}>{option.code}</strong> - <strong>{option.label}</strong>
+                            </div>
+                            {option.details && <small className="text-muted" style={{ fontSize: '12px' }}>{option.details}</small>}
+                          </div>
+                          <Badge style={{ backgroundColor: '#0891B2', color: 'white', fontSize: '11px' }}>Rs. {option.price?.toFixed(2)}</Badge>
+                        </div>
+                      )
+                    }}
+                    styles={testSelectStyles}
+                  />
+                </Form.Group>
+
+                <Form.Group className="mb-3">
+                  <Form.Label>
+                    Total Amount: <Badge style={{ backgroundColor: '#06B6D4', color: 'white' }} className="fs-6">Rs. {calculateTotal().toFixed(2)}</Badge>
+                  </Form.Label>
+                </Form.Group>
+
+                {/* Weight/Height Section */}
+                <h6 style={{ color: '#0891B2', borderBottom: '2px solid #e0f2fe', paddingBottom: '0.5rem', marginBottom: '1rem', marginTop: '1.5rem' }}>
+                  Measurements (Optional)
+                </h6>
+
+                <Row>
+                  <Col md={6}>
+                    <Form.Group className="mb-3">
+                      <Form.Label>Weight (kg)</Form.Label>
+                      <Form.Control
+                        type="number"
+                        step="0.1"
+                        value={formData.weight}
+                        onChange={(e) => setFormData({ ...formData, weight: e.target.value })}
+                        placeholder="Enter weight in kg (optional)"
+                      />
+                    </Form.Group>
+                  </Col>
+                  <Col md={6}>
+                    <Form.Group className="mb-3">
+                      <Form.Label>Height (cm)</Form.Label>
+                      <Form.Control
+                        type="number"
+                        step="0.1"
+                        value={formData.height}
+                        onChange={(e) => setFormData({ ...formData, height: e.target.value })}
+                        placeholder="Enter height in cm (optional)"
+                      />
+                    </Form.Group>
+                  </Col>
+                </Row>
+
+                <div style={{ padding: '1rem', backgroundColor: '#e0f2fe', borderRadius: '0.375rem', marginTop: '1rem' }}>
+                  <p style={{ fontSize: '0.9rem', color: '#0369a1', marginBottom: 0 }}>
+                    <strong>Note:</strong> You can add detailed notes and prescriptions after creating the checkup by clicking on "View Details" and using the Notes & Prescription tabs.
+                  </p>
+                </div>
+              </Card.Body>
+
+              <Card.Footer className="entity-form-footer">
+                <Button
+                  variant="outline-secondary"
+                  onClick={() => navigate(isNew ? '/checkups' : `/checkups/${id}`)}
+                  disabled={isSubmitting}
+                  className="entity-form-btn"
+                >
+                  <FaArrowLeft className="me-1" />
+                  {isNew ? 'Back' : 'Cancel'}
+                </Button>
+
+                <div className="entity-form-actions">
+                  {canDelete && (
+                    <Button
+                      variant="outline-danger"
+                      onClick={handleDelete}
+                      disabled={isSubmitting}
+                      className="entity-form-btn"
+                    >
+                      <FaTrash className="me-1" />
+                      Delete
+                    </Button>
+                  )}
+                  <Button
+                    type="submit"
+                    disabled={isSubmitting || loading}
+                    className="entity-form-btn"
+                    style={{
+                      backgroundColor: '#06B6D4',
+                      border: 'none',
+                      color: 'white',
+                    }}
+                  >
+                    <FaSave className="me-1" />
+                    {isSubmitting ? 'Saving...' : (isNew ? 'Create Checkup' : 'Update Checkup')}
+                  </Button>
+                </div>
+
+                <style>{`
+                  .entity-form-body {
+                    padding: 1.25rem;
+                  }
+                  .entity-form-footer {
+                    display: flex;
+                    flex-wrap: wrap;
+                    gap: 0.5rem;
+                    justify-content: space-between;
+                    align-items: center;
+                    padding: 0.75rem 1.25rem;
+                  }
+                  .entity-form-actions {
+                    display: flex;
+                    gap: 0.5rem;
+                    flex-wrap: wrap;
+                  }
+                  .entity-form-btn {
+                    min-width: 100px;
+                    min-height: 44px;
+                  }
+
+                  @media (max-width: 767px) {
+                    .entity-form-body {
+                      padding: 0.75rem;
+                    }
+                    .entity-form-footer {
+                      flex-direction: column;
+                      gap: 0.5rem;
+                      padding: 0.75rem;
+                    }
+                    .entity-form-actions {
+                      width: 100%;
+                      flex-direction: column;
+                    }
+                    .entity-form-btn {
+                      width: 100%;
+                      min-height: 48px;
+                      font-size: 1rem;
+                    }
+                  }
+                `}</style>
+              </Card.Footer>
+            </Form>
+          </Card>
+        </Col>
+      </Row>
+    </Container>
+  )
+}
+
+export default CheckupForm

--- a/src/pages/Checkups.jsx
+++ b/src/pages/Checkups.jsx
@@ -1,15 +1,14 @@
-import { useState, useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
-import { Container, Row, Col, Card, Button, Table, Modal, Form, Badge } from 'react-bootstrap'
-import { FaPlus, FaEdit, FaTrash, FaClipboardCheck } from 'react-icons/fa'
-import Select from 'react-select'
-import { fetchCheckups, addCheckup, updateCheckup, deleteCheckup, selectAllCheckups } from '../store/checkupsSlice'
-import { fetchPatients, addPatient, selectAllPatients } from '../store/patientsSlice'
+import { Container, Row, Col, Card, Button, Badge } from 'react-bootstrap'
+import { FaPlus, FaClipboardCheck } from 'react-icons/fa'
+import { fetchCheckups, selectAllCheckups } from '../store/checkupsSlice'
+import { fetchPatients, selectAllPatients } from '../store/patientsSlice'
 import { fetchTests, selectAllTests } from '../store/testsSlice'
 import LoadingSpinner from '../components/common/LoadingSpinner'
-import ErrorAlert from '../components/common/ErrorAlert'
-import { PermissionGate, usePermission } from '../components/auth/PermissionGate'
+import { EnhancedCRUDTable } from '../components/crud'
+import { PermissionGate } from '../components/auth/PermissionGate'
 
 function Checkups() {
   const dispatch = useDispatch()
@@ -20,25 +19,6 @@ function Checkups() {
   const { loading: checkupsLoading, error: checkupsError } = useSelector(state => state.checkups)
   const { loading: patientsLoading } = useSelector(state => state.patients)
   const { loading: testsLoading } = useSelector(state => state.tests)
-  const { checkPermission } = usePermission()
-  const [showModal, setShowModal] = useState(false)
-  const [editingCheckup, setEditingCheckup] = useState(null)
-  const [currentStep, setCurrentStep] = useState(1)
-  const [showNewPatientForm, setShowNewPatientForm] = useState(false)
-  const [formData, setFormData] = useState({
-    patientId: '',
-    tests: [],
-    weight: '',
-    height: ''
-  })
-  const [newPatientData, setNewPatientData] = useState({
-    name: '',
-    age: '',
-    gender: 'Male',
-    mobile: '',
-    email: '',
-    address: ''
-  })
 
   const loading = checkupsLoading || patientsLoading || testsLoading
 
@@ -48,105 +28,6 @@ function Checkups() {
     dispatch(fetchTests())
   }, [dispatch])
 
-  const handleClose = () => {
-    setShowModal(false)
-    setEditingCheckup(null)
-    setCurrentStep(1)
-    setShowNewPatientForm(false)
-    setFormData({ patientId: '', tests: [], weight: '', height: '' })
-    setNewPatientData({ name: '', age: '', gender: 'Male', mobile: '', email: '', address: '' })
-  }
-
-  const handleShow = (checkup = null) => {
-    if (checkup) {
-      setEditingCheckup(checkup)
-      setCurrentStep(2) // Skip to step 2 when editing
-      setFormData({
-        patientId: checkup.patientId,
-        tests: checkup.tests,
-        weight: checkup.weight || '',
-        height: checkup.height || ''
-      })
-    }
-    setShowModal(true)
-  }
-
-  const handlePatientSelect = (selectedOption) => {
-    if (selectedOption) {
-      setFormData(prev => ({ ...prev, patientId: selectedOption.value }))
-      setShowNewPatientForm(false)
-    }
-  }
-
-  const handleCreateNewPatient = async () => {
-    try {
-      const result = await dispatch(addPatient(newPatientData))
-      if (result.payload?.id) {
-        setFormData(prev => ({ ...prev, patientId: result.payload.id }))
-        setShowNewPatientForm(false)
-        setCurrentStep(2)
-      }
-    } catch (error) {
-      console.error('Error creating patient:', error)
-    }
-  }
-
-  const handleNextStep = () => {
-    if (currentStep === 1 && formData.patientId) {
-      setCurrentStep(2)
-    }
-  }
-
-  const handlePreviousStep = () => {
-    setCurrentStep(1)
-  }
-
-  const handleTestChange = (selectedOptions) => {
-    const newTests = selectedOptions ? selectedOptions.map(option => ({
-      testId: option.value
-    })) : []
-
-    setFormData(prev => ({
-      ...prev,
-      tests: newTests
-    }))
-  }
-
-  const calculateTotal = () => {
-    return formData.tests.reduce((sum, testItem) => {
-      const test = tests.find(t => t.id === testItem.testId)
-      return sum + (test?.price || 0)
-    }, 0)
-  }
-
-  const handleSubmit = async (e) => {
-    e.preventDefault()
-
-    if (formData.tests.length === 0) {
-      alert('Please select at least one test')
-      return
-    }
-
-    const checkupData = {
-      ...formData,
-      patientId: formData.patientId,
-      total: calculateTotal()
-    }
-
-    if (editingCheckup) {
-      await dispatch(updateCheckup({ id: editingCheckup.id, ...checkupData, timestamp: editingCheckup.timestamp }))
-    } else {
-      await dispatch(addCheckup(checkupData))
-    }
-    handleClose()
-  }
-
-  const handleDelete = async (id) => {
-    if (window.confirm('Are you sure you want to delete this checkup?')) {
-      await dispatch(deleteCheckup(id))
-    }
-  }
-
   if (loading && checkups.length === 0) {
     return <LoadingSpinner text="Loading checkups data..." />
   }
@@ -155,20 +36,81 @@ function Checkups() {
     navigate(`/checkups/${checkupId}`)
   }
 
-  const getPatientName = (patientId) => {
-    const patient = patients.find(p => p.id === patientId)
-    return patient ? patient.name : 'Unknown'
-  }
+  // Enrich checkups with resolved patient name and test names for search
+  const enrichedCheckups = useMemo(() => {
+    return checkups.map(checkup => {
+      const patient = patients.find(p => p.id === checkup.patientId)
+      const testNames = checkup.tests
+        .map(t => { const test = tests.find(x => x.id === t.testId); return test ? test.name : null })
+        .filter(Boolean)
+        .join(', ')
+      return {
+        ...checkup,
+        patientName: patient ? patient.name : 'Unknown',
+        testNames,
+      }
+    })
+  }, [checkups, patients, tests])
 
-  const getTestNames = (testItems) => {
-    return testItems
-      .map(testItem => {
-        const test = tests.find(t => t.id === testItem.testId)
-        return test ? test.name : null
-      })
-      .filter(Boolean)
-      .join(', ')
-  }
+  const TABLE_COLUMNS = [
+    {
+      key: 'billNo',
+      label: 'Bill No',
+      render: (value, item) => (
+        <Badge
+          onClick={() => handleViewDetails(item.id)}
+          style={{
+            backgroundColor: '#06B6D4',
+            color: 'white',
+            cursor: 'pointer',
+            transition: 'all 0.2s',
+            fontSize: 'clamp(0.75rem, 1.5vw, 0.85rem)',
+          }}
+          onMouseEnter={(e) => e.target.style.backgroundColor = '#0891B2'}
+          onMouseLeave={(e) => e.target.style.backgroundColor = '#06B6D4'}
+        >
+          {value || `#${item.id}`}
+        </Badge>
+      )
+    },
+    {
+      key: 'patientName',
+      label: 'Patient',
+      render: (value) => (
+        <strong style={{ fontSize: 'clamp(0.85rem, 2vw, 1rem)' }}>{value}</strong>
+      )
+    },
+    {
+      key: 'testNames',
+      label: 'Tests',
+      render: (value) => (
+        <div style={{
+          maxWidth: window.innerWidth < 768 ? '150px' : '300px',
+          wordWrap: 'break-word',
+          fontSize: 'clamp(0.8rem, 2vw, 0.875rem)',
+          lineHeight: '1.4'
+        }}>
+          {value || '-'}
+        </div>
+      )
+    },
+    {
+      key: 'total',
+      label: 'Total (Rs.)',
+      render: (value) => (
+        <strong style={{ fontSize: 'clamp(0.85rem, 2vw, 1rem)' }}>Rs. {value?.toFixed(2)}</strong>
+      )
+    },
+    {
+      key: 'timestamp',
+      label: 'Date/Time',
+      render: (value) => (
+        <span style={{ fontSize: 'clamp(0.8rem, 2vw, 0.9rem)', whiteSpace: 'nowrap' }}>
+          {new Date(value).toLocaleString()}
+        </span>
+      )
+    },
+  ]
 
   return (
     <Container fluid className="p-3 p-md-4">
@@ -178,7 +120,7 @@ function Checkups() {
             <h2><FaClipboardCheck className="me-2 text-secondary" />Checkups / Billing</h2>
             <PermissionGate resource="checkups" action="create">
               <Button
-                onClick={() => handleShow()}
+                onClick={() => navigate('/checkups/new')}
                 className="mt-2 mt-md-0"
                 disabled={patients.length === 0 || loading}
                 style={{
@@ -197,14 +139,6 @@ function Checkups() {
         </Col>
       </Row>
 
-      {checkupsError && (
-        <Row className="mb-3">
-          <Col>
-            <ErrorAlert error={checkupsError} />
-          </Col>
-        </Row>
-      )}
-
       {patients.length === 0 && !patientsLoading && (
         <Row className="mb-3">
           <Col>
@@ -219,434 +153,17 @@ function Checkups() {
 
       <Row>
         <Col>
-          <Card>
-            <Card.Body className="p-0">
-              <div className="table-responsive">
-                <Table striped hover className="mb-0 table-mobile-responsive">
-                  <thead>
-                    <tr>
-                      <th>Bill No</th>
-                      <th>Patient</th>
-                      <th>Tests</th>
-                      <th>Total (Rs.)</th>
-                      <th>Date/Time</th>
-                      {(checkPermission('checkups', 'edit') || checkPermission('checkups', 'delete')) && (
-                        <th className="text-center">Actions</th>
-                      )}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {checkups.length === 0 ? (
-                      <tr>
-                        <td colSpan={(checkPermission('checkups', 'edit') || checkPermission('checkups', 'delete')) ? "6" : "5"} className="text-center py-4 text-muted">
-                          No checkups recorded yet
-                        </td>
-                      </tr>
-                    ) : (
-                      checkups.map(checkup => (
-                        <tr key={checkup.id}>
-                          <td data-label="Bill No">
-                            <Badge
-                              onClick={() => handleViewDetails(checkup.id)}
-                              style={{
-                                backgroundColor: '#06B6D4',
-                                color: 'white',
-                                cursor: 'pointer',
-                                transition: 'all 0.2s'
-                              }}
-                              onMouseEnter={(e) => e.target.style.backgroundColor = '#0891B2'}
-                              onMouseLeave={(e) => e.target.style.backgroundColor = '#06B6D4'}
-                            >
-                              {checkup.billNo || `#${checkup.id}`}
-                            </Badge>
-                          </td>
-                          <td data-label="Patient"><strong>{getPatientName(checkup.patientId)}</strong></td>
-                          <td data-label="Tests">
-                            <div
-                              style={{
-                                maxWidth: window.innerWidth < 768 ? '150px' : '300px',
-                                maxHeight: '80px',
-                                overflowY: 'auto',
-                                overflowX: 'hidden',
-                                wordWrap: 'break-word',
-                                fontSize: '0.875rem',
-                                lineHeight: '1.4'
-                              }}
-                            >
-                              {getTestNames(checkup.tests)}
-                            </div>
-                          </td>
-                          <td data-label="Total"><strong>Rs. {checkup.total.toFixed(2)}</strong></td>
-                          <td data-label="Date/Time">{new Date(checkup.timestamp).toLocaleString()}</td>
-                          {(checkPermission('checkups', 'edit') || checkPermission('checkups', 'delete')) && (
-                            <td data-label="Actions">
-                              <div className="d-flex gap-2 justify-content-center flex-wrap">
-                                <PermissionGate resource="checkups" action="edit">
-                                  <Button
-                                    size="sm"
-                                    onClick={() => handleShow(checkup)}
-                                    disabled={loading}
-                                    style={{
-                                      backgroundColor: '#0891B2',
-                                      border: 'none',
-                                      color: 'white'
-                                    }}
-                                  >
-                                    <FaEdit />
-                                  </Button>
-                                </PermissionGate>
-                                <PermissionGate resource="checkups" action="delete">
-                                  <Button
-                                    size="sm"
-                                    onClick={() => handleDelete(checkup.id)}
-                                    disabled={loading}
-                                    style={{
-                                      backgroundColor: '#ef4444',
-                                      border: 'none',
-                                      color: 'white'
-                                    }}
-                                  >
-                                    <FaTrash />
-                                  </Button>
-                                </PermissionGate>
-                              </div>
-                            </td>
-                          )}
-                        </tr>
-                      ))
-                    )}
-                  </tbody>
-                </Table>
-              </div>
-            </Card.Body>
-          </Card>
+          <EnhancedCRUDTable
+            data={enrichedCheckups}
+            columns={TABLE_COLUMNS}
+            loading={loading}
+            error={checkupsError}
+            emptyMessage="No checkups recorded yet"
+            itemsPerPage={10}
+            searchFields={['billNo', 'patientName', 'testNames']}
+          />
         </Col>
       </Row>
-
-      <Modal show={showModal} onHide={handleClose} size="lg" fullscreen="md-down">
-        <Modal.Header closeButton>
-          <Modal.Title>
-            {editingCheckup ? 'Edit Checkup' : 'New Checkup / Bill'}
-            {!editingCheckup && <span className="ms-2 text-muted" style={{ fontSize: '14px' }}>Step {currentStep} of 2</span>}
-          </Modal.Title>
-        </Modal.Header>
-        <Form onSubmit={handleSubmit}>
-          <Modal.Body>
-            {/* Step 1: Patient Selection/Creation */}
-            {currentStep === 1 && !editingCheckup && (
-              <>
-                <Form.Group className="mb-3">
-                  <Form.Label>Select Patient *</Form.Label>
-                  <Select
-                    options={patients.map(patient => ({
-                      value: patient.id,
-                      label: `${patient.name} - ${patient.age}yr - ${patient.mobile}`,
-                      patient: patient
-                    }))}
-                    value={patients
-                      .filter(p => p.id === formData.patientId)
-                      .map(patient => ({
-                        value: patient.id,
-                        label: `${patient.name} - ${patient.age}yr - ${patient.mobile}`
-                      }))[0] || null}
-                    onChange={handlePatientSelect}
-                    placeholder="Search patient by name, mobile..."
-                    isClearable
-                    formatOptionLabel={(option) => (
-                      <div>
-                        <div><strong>{option.patient?.name || option.label.split(' - ')[0]}</strong></div>
-                        <small className="text-muted">
-                          {option.patient?.age}yr, {option.patient?.gender} - {option.patient?.mobile}
-                        </small>
-                      </div>
-                    )}
-                  />
-                </Form.Group>
-
-                <div className="text-center mb-3">
-                  <Button
-                    variant="link"
-                    onClick={() => setShowNewPatientForm(!showNewPatientForm)}
-                  >
-                    {showNewPatientForm ? 'Cancel' : '+ Add New Patient'}
-                  </Button>
-                </div>
-
-                {showNewPatientForm && (
-                  <Card className="mb-3">
-                    <Card.Header className="bg-light">
-                      <strong>New Patient Information</strong>
-                    </Card.Header>
-                    <Card.Body>
-                      <Row>
-                        <Col md={6}>
-                          <Form.Group className="mb-3">
-                            <Form.Label>Name *</Form.Label>
-                            <Form.Control
-                              type="text"
-                              value={newPatientData.name}
-                              onChange={(e) => setNewPatientData({ ...newPatientData, name: e.target.value })}
-                              required
-                            />
-                          </Form.Group>
-                        </Col>
-                        <Col md={3}>
-                          <Form.Group className="mb-3">
-                            <Form.Label>Age *</Form.Label>
-                            <Form.Control
-                              type="number"
-                              value={newPatientData.age}
-                              onChange={(e) => setNewPatientData({ ...newPatientData, age: e.target.value })}
-                              required
-                            />
-                          </Form.Group>
-                        </Col>
-                        <Col md={3}>
-                          <Form.Group className="mb-3">
-                            <Form.Label>Gender *</Form.Label>
-                            <Form.Select
-                              value={newPatientData.gender}
-                              onChange={(e) => setNewPatientData({ ...newPatientData, gender: e.target.value })}
-                            >
-                              <option>Male</option>
-                              <option>Female</option>
-                              <option>Other</option>
-                            </Form.Select>
-                          </Form.Group>
-                        </Col>
-                        <Col md={6}>
-                          <Form.Group className="mb-3">
-                            <Form.Label>Mobile *</Form.Label>
-                            <Form.Control
-                              type="tel"
-                              value={newPatientData.mobile}
-                              onChange={(e) => setNewPatientData({ ...newPatientData, mobile: e.target.value })}
-                              required
-                            />
-                          </Form.Group>
-                        </Col>
-                        <Col md={6}>
-                          <Form.Group className="mb-3">
-                            <Form.Label>Email</Form.Label>
-                            <Form.Control
-                              type="email"
-                              value={newPatientData.email}
-                              onChange={(e) => setNewPatientData({ ...newPatientData, email: e.target.value })}
-                            />
-                          </Form.Group>
-                        </Col>
-                        <Col md={12}>
-                          <Form.Group className="mb-3">
-                            <Form.Label>Address *</Form.Label>
-                            <Form.Control
-                              as="textarea"
-                              rows={2}
-                              value={newPatientData.address}
-                              onChange={(e) => setNewPatientData({ ...newPatientData, address: e.target.value })}
-                              required
-                            />
-                          </Form.Group>
-                        </Col>
-                      </Row>
-                      <Button variant="primary" onClick={handleCreateNewPatient} size="sm">
-                        Create Patient & Continue
-                      </Button>
-                    </Card.Body>
-                  </Card>
-                )}
-              </>
-            )}
-
-            {/* Step 2: Test Selection */}
-            {(currentStep === 2 || editingCheckup) && (
-              <>
-                {currentStep === 2 && !editingCheckup && (
-                  <div className="alert alert-info mb-3">
-                    <strong>Patient:</strong> {patients.find(p => p.id === formData.patientId)?.name}
-                    <Button
-                      variant="link"
-                      size="sm"
-                      className="float-end"
-                      onClick={handlePreviousStep}
-                    >
-                      Change Patient
-                    </Button>
-                  </div>
-                )}
-
-                {editingCheckup && (
-                  <Form.Group className="mb-3">
-                    <Form.Label>Patient</Form.Label>
-                    <Form.Control
-                      type="text"
-                      value={patients.find(p => p.id === formData.patientId)?.name || 'Unknown'}
-                      disabled
-                    />
-                  </Form.Group>
-                )}
-
-                <Form.Group className="mb-3">
-              <Form.Label>Select Tests *</Form.Label>
-              <Select
-                isMulti
-                options={tests.map(test => ({
-                  value: test.id,
-                  label: test.name,
-                  code: test.code,
-                  price: test.price,
-                  details: test.details
-                }))}
-                value={tests
-                  .filter(test => formData.tests.some(t => t.testId === test.id))
-                  .map(test => ({
-                    value: test.id,
-                    label: test.name,
-                    code: test.code
-                  }))}
-                onChange={handleTestChange}
-                isDisabled={loading}
-                placeholder="Search tests by name or code..."
-                formatOptionLabel={(option, { context }) => {
-                  if (context === 'value') {
-                    // In tags - show code and name
-                    return (
-                      <span>
-                        <strong style={{ color: '#0891B2' }}>{option.code}</strong> - {option.label}
-                      </span>
-                    )
-                  }
-                  // In dropdown - show code, name, details and price
-                  return (
-                    <div className="d-flex justify-content-between align-items-center">
-                      <div>
-                        <div style={{ fontSize: '14px' }}>
-                          <strong style={{ color: '#0891B2' }}>{option.code}</strong> - <strong>{option.label}</strong>
-                        </div>
-                        {option.details && <small className="text-muted" style={{ fontSize: '12px' }}>{option.details}</small>}
-                      </div>
-                      <Badge style={{ backgroundColor: '#0891B2', color: 'white', fontSize: '11px' }}>Rs. {option.price?.toFixed(2)}</Badge>
-                    </div>
-                  )
-                }}
-                styles={{
-                  control: (base) => ({
-                    ...base,
-                    minHeight: '38px',
-                    fontSize: '14px'
-                  }),
-                  valueContainer: (base) => ({
-                    ...base,
-                    padding: '2px 8px',
-                    gap: '3px'
-                  }),
-                  multiValue: (base) => ({
-                    ...base,
-                    backgroundColor: '#0dcaf0',
-                    borderRadius: '3px',
-                    margin: '2px'
-                  }),
-                  multiValueLabel: (base) => ({
-                    ...base,
-                    color: 'white',
-                    fontSize: '13px',
-                    padding: '2px 8px'
-                  }),
-                  multiValueRemove: (base) => ({
-                    ...base,
-                    color: 'white',
-                    padding: '2px 4px',
-                    ':hover': {
-                      backgroundColor: '#0aa2c0',
-                      color: 'white'
-                    }
-                  }),
-                  option: (base) => ({
-                    ...base,
-                    padding: '8px 12px'
-                  }),
-                  menu: (base) => ({
-                    ...base,
-                    fontSize: '14px'
-                  }),
-                  placeholder: (base) => ({
-                    ...base,
-                    fontSize: '14px'
-                  })
-                }}
-              />
-            </Form.Group>
-
-            <Form.Group className="mb-3">
-              <Form.Label>
-                Total Amount: <Badge style={{ backgroundColor: '#06B6D4', color: 'white' }} className="fs-6">Rs. {calculateTotal().toFixed(2)}</Badge>
-              </Form.Label>
-            </Form.Group>
-
-                <Row>
-                  <Col md={6}>
-                    <Form.Group className="mb-3">
-                      <Form.Label>Weight (kg)</Form.Label>
-                      <Form.Control
-                        type="number"
-                        step="0.1"
-                        value={formData.weight}
-                        onChange={(e) => setFormData({ ...formData, weight: e.target.value })}
-                        placeholder="Enter weight in kg (optional)"
-                      />
-                    </Form.Group>
-                  </Col>
-                  <Col md={6}>
-                    <Form.Group className="mb-3">
-                      <Form.Label>Height (cm)</Form.Label>
-                      <Form.Control
-                        type="number"
-                        step="0.1"
-                        value={formData.height}
-                        onChange={(e) => setFormData({ ...formData, height: e.target.value })}
-                        placeholder="Enter height in cm (optional)"
-                      />
-                    </Form.Group>
-                  </Col>
-                </Row>
-
-                <div style={{ padding: '1rem', backgroundColor: '#e0f2fe', borderRadius: '0.375rem', marginTop: '1rem' }}>
-                  <p style={{ fontSize: '0.9rem', color: '#0369a1', marginBottom: 0 }}>
-                    <strong>Note:</strong> You can add detailed notes and prescriptions after creating the checkup by clicking on "View Details" and using the Notes & Prescription tabs.
-                  </p>
-                </div>
-              </>
-            )}
-          </Modal.Body>
-          <Modal.Footer>
-            <Button variant="secondary" onClick={handleClose}>
-              Cancel
-            </Button>
-
-            {currentStep === 1 && !editingCheckup && (
-              <Button
-                variant="primary"
-                onClick={handleNextStep}
-                disabled={!formData.patientId}
-              >
-                Next: Select Tests
-              </Button>
-            )}
-
-            {(currentStep === 2 || editingCheckup) && (
-              <>
-                {currentStep === 2 && !editingCheckup && (
-                  <Button variant="outline-secondary" onClick={handlePreviousStep}>
-                    Back
-                  </Button>
-                )}
-                <Button variant="primary" type="submit">
-                  {editingCheckup ? 'Update' : 'Create'} Checkup
-                </Button>
-              </>
-            )}
-          </Modal.Footer>
-        </Form>
-      </Modal>
     </Container>
   )
 }

--- a/src/pages/MedicineDetail.jsx
+++ b/src/pages/MedicineDetail.jsx
@@ -1,0 +1,446 @@
+import { useEffect, useCallback, useState } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { useSelector, useDispatch } from 'react-redux'
+import { Container, Row, Col, Card, Button, Form, Badge } from 'react-bootstrap'
+import { FaPills, FaArrowLeft, FaTimes } from 'react-icons/fa'
+import { selectAllMedicines, addMedicine, updateMedicine, deleteMedicine, fetchMedicines } from '../store/medicinesSlice'
+import { useForm } from '../hooks'
+import { useNotification } from '../context'
+import { EntityForm } from '../components/crud'
+import { usePermission } from '../components/auth/PermissionGate'
+import FormField from '../components/ui/FormField'
+import RichTextEditor from '../components/ui/RichTextEditor'
+
+const INITIAL_FORM = {
+  code: '',
+  name: '',
+  brand: '',
+  dosage: [],
+  unit: '',
+  description: '',
+  details: '',
+};
+
+// Normalize dosage from Firebase (could be string or array)
+const normalizeDosage = (dosage) => {
+  if (Array.isArray(dosage)) return dosage
+  if (typeof dosage === 'string' && dosage.trim()) {
+    return dosage.split(',').map(d => d.trim()).filter(Boolean)
+  }
+  return []
+}
+
+// Multi-tag input for dosage values (comma-triggered)
+const DosageInput = ({ values: rawValues, onChange, disabled }) => {
+  const values = normalizeDosage(rawValues)
+  const [input, setInput] = useState('')
+
+  const addDosage = (text) => {
+    const trimmed = text.trim()
+    if (!trimmed || values.includes(trimmed)) return
+    onChange([...values, trimmed])
+  }
+
+  const removeDosage = (index) => {
+    onChange(values.filter((_, i) => i !== index))
+  }
+
+  const handleChange = (e) => {
+    const val = e.target.value
+    if (val.includes(',')) {
+      const parts = val.split(',')
+      parts.forEach((part, i) => {
+        if (i < parts.length - 1) addDosage(part)
+      })
+      setInput(parts[parts.length - 1])
+    } else {
+      setInput(val)
+    }
+  }
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      if (input.trim()) {
+        addDosage(input)
+        setInput('')
+      }
+    }
+    if (e.key === 'Backspace' && !input && values.length > 0) {
+      removeDosage(values.length - 1)
+    }
+  }
+
+  const handleBlur = () => {
+    if (input.trim()) {
+      addDosage(input)
+      setInput('')
+    }
+  }
+
+  return (
+    <Form.Group className="mb-3">
+      <Form.Label>
+        Dosage <span className="text-danger ms-1">*</span>
+      </Form.Label>
+      <div
+        className="dosage-tag-input"
+        onClick={(e) => {
+          const inp = e.currentTarget.querySelector('input')
+          if (inp) inp.focus()
+        }}
+      >
+        {values.map((dosage, index) => (
+          <span key={index} className="dosage-tag">
+            {dosage}
+            {!disabled && (
+              <FaTimes
+                className="dosage-tag-remove"
+                onClick={(e) => { e.stopPropagation(); removeDosage(index) }}
+              />
+            )}
+          </span>
+        ))}
+        <input
+          type="text"
+          value={input}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          onBlur={handleBlur}
+          placeholder={values.length === 0 ? 'Type dosage, press comma (e.g. 10ml, 20ml)' : ''}
+          disabled={disabled}
+          className="dosage-tag-text-input"
+        />
+      </div>
+
+      <style>{`
+        .dosage-tag-input {
+          display: flex;
+          flex-wrap: wrap;
+          align-items: center;
+          gap: 0.4rem;
+          padding: 0.5rem 0.75rem;
+          border: 1px solid #ced4da;
+          border-radius: 0.375rem;
+          background-color: ${disabled ? '#e9ecef' : '#fff'};
+          cursor: ${disabled ? 'not-allowed' : 'text'};
+          min-height: 44px;
+          transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+        }
+        .dosage-tag-input:focus-within {
+          border-color: #0891B2;
+          box-shadow: 0 0 0 0.2rem rgba(8, 145, 178, 0.25);
+        }
+        .dosage-tag {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.35rem;
+          background-color: #059669;
+          color: white;
+          font-size: clamp(0.8rem, 2vw, 0.9rem);
+          font-weight: 600;
+          padding: 0.3rem 0.55rem;
+          border-radius: 0.25rem;
+          white-space: nowrap;
+          min-height: 28px;
+        }
+        .dosage-tag-remove {
+          cursor: pointer;
+          opacity: 0.8;
+          font-size: 0.6rem;
+          min-width: 14px;
+          min-height: 14px;
+          padding: 2px;
+        }
+        .dosage-tag-remove:hover {
+          opacity: 1;
+        }
+        .dosage-tag-text-input {
+          border: none;
+          outline: none;
+          flex: 1;
+          min-width: 120px;
+          background-color: transparent;
+          font-size: 1rem;
+          padding: 0.15rem 0;
+          line-height: 1.5;
+        }
+        .dosage-tag-text-input::placeholder {
+          color: #9ca3af;
+          font-size: clamp(0.8rem, 2vw, 0.95rem);
+        }
+
+        @media (max-width: 767px) {
+          .dosage-tag-input {
+            padding: 0.5rem;
+            gap: 0.35rem;
+            min-height: 48px;
+          }
+          .dosage-tag {
+            padding: 0.35rem 0.6rem;
+            font-size: 0.85rem;
+            min-height: 32px;
+          }
+          .dosage-tag-remove {
+            min-width: 20px;
+            min-height: 20px;
+            padding: 4px;
+          }
+          .dosage-tag-text-input {
+            min-width: 100px;
+            font-size: 16px; /* prevents iOS zoom on focus */
+            padding: 0.25rem 0;
+          }
+        }
+      `}</style>
+    </Form.Group>
+  )
+}
+
+function MedicineDetail() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const dispatch = useDispatch()
+  const medicines = useSelector(selectAllMedicines)
+  const { loading } = useSelector(state => state.medicines)
+  const { success, error: showError } = useNotification()
+  const { checkPermission } = usePermission()
+
+  const isNew = id === 'new'
+  const medicine = isNew ? null : medicines.find(m => m.id === id)
+
+  const validate = useCallback((data) => {
+    const errors = {}
+    // Only check code uniqueness if code was changed from original
+    const codeChanged = isNew || data.code?.toLowerCase() !== medicine?.code?.toLowerCase()
+    if (codeChanged) {
+      const codeExists = medicines.find(m =>
+        m.code?.toLowerCase() === data.code?.toLowerCase() &&
+        m.id !== id
+      )
+      if (codeExists) {
+        errors.code = `Medicine code "${data.code}" already exists. Please use a unique code.`
+      }
+    }
+    const dosageList = normalizeDosage(data.dosage)
+    if (dosageList.length === 0) {
+      errors.dosage = 'At least one dosage is required.'
+    }
+    return errors
+  }, [medicines, id, isNew, medicine?.code])
+
+  const handleFormSubmit = useCallback(async (formData) => {
+    const dataToSubmit = {
+      ...formData,
+      dosage: normalizeDosage(formData.dosage),
+    }
+
+    try {
+      if (isNew) {
+        const result = await dispatch(addMedicine(dataToSubmit))
+        if (result.type.includes('rejected')) {
+          throw new Error(result.payload || 'Failed to add medicine')
+        }
+        success('Medicine added successfully!')
+        navigate(`/medicines/${result.payload.id}`, { replace: true })
+      } else {
+        const result = await dispatch(updateMedicine({ id, ...dataToSubmit }))
+        if (result.type.includes('rejected')) {
+          throw new Error(result.payload || 'Failed to update medicine')
+        }
+        success('Medicine updated successfully!')
+      }
+    } catch (err) {
+      showError(err.message || 'Operation failed')
+      throw err
+    }
+  }, [isNew, id, dispatch, navigate, success, showError])
+
+  const form = useForm(INITIAL_FORM, handleFormSubmit, validate)
+
+  // Load medicine data into form when editing
+  useEffect(() => {
+    if (medicine) {
+      form.resetTo({
+        code: medicine.code || '',
+        name: medicine.name || '',
+        brand: medicine.brand || '',
+        dosage: normalizeDosage(medicine.dosage),
+        unit: medicine.unit || '',
+        description: medicine.description || '',
+        details: medicine.details || '',
+      })
+    }
+  }, [medicine?.id]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Fetch medicines if store is empty
+  useEffect(() => {
+    if (medicines.length === 0) {
+      dispatch(fetchMedicines())
+    }
+  }, [dispatch, medicines.length])
+
+  const handleDelete = async () => {
+    if (!window.confirm('Are you sure you want to delete this medicine?')) return
+    try {
+      const result = await dispatch(deleteMedicine(id))
+      if (result.type.includes('rejected')) {
+        throw new Error(result.payload || 'Failed to delete medicine')
+      }
+      success('Medicine deleted successfully!')
+      navigate('/medicines')
+    } catch (err) {
+      showError(err.message || 'Delete failed')
+    }
+  }
+
+  // Not found
+  if (!isNew && !medicine && medicines.length > 0) {
+    return (
+      <Container fluid className="p-3 p-md-4">
+        <Card>
+          <Card.Body className="text-center py-5">
+            <h4>Medicine not found</h4>
+            <Button
+              onClick={() => navigate('/medicines')}
+              style={{ backgroundColor: '#06B6D4', border: 'none', color: 'white' }}
+            >
+              <FaArrowLeft className="me-2" />
+              Back to Medicines
+            </Button>
+          </Card.Body>
+        </Card>
+      </Container>
+    )
+  }
+
+  const canEdit = checkPermission('medicines', isNew ? 'create' : 'edit')
+  const canDelete = !isNew && checkPermission('medicines', 'delete')
+  const isDisabled = form.isSubmitting || loading || !canEdit
+
+  return (
+    <Container fluid className="p-3 p-md-4">
+      <Row className="mb-4">
+        <Col>
+          <h2 style={{ fontSize: 'clamp(1.2rem, 3vw, 1.75rem)' }}>
+            <FaPills className="me-2" style={{ color: '#0891B2' }} />
+            {isNew ? 'Add New Medicine' : 'Medicine Details'}
+          </h2>
+        </Col>
+      </Row>
+
+      <Row>
+        <Col>
+          <EntityForm
+            title={isNew ? 'New Medicine Information' : `Edit Medicine: ${medicine?.name || ''}`}
+            formData={form.formData}
+            formErrors={form.errors}
+            onFormChange={form.handleChange}
+            onSubmit={form.handleSubmit}
+            onCancel={() => navigate('/medicines')}
+            onDelete={canDelete ? handleDelete : undefined}
+            loading={form.isSubmitting || loading}
+            isEditing={!isNew}
+          >
+            <Row className="g-3">
+              {/* Code */}
+              <Col xs={12} md={6}>
+                <FormField
+                  label="Medicine Code"
+                  name="code"
+                  type="text"
+                  value={form.formData.code || ''}
+                  onChange={form.handleChange}
+                  error={form.errors.code}
+                  required
+                  placeholder="e.g., MED001"
+                  disabled={isDisabled}
+                />
+              </Col>
+              {/* Name */}
+              <Col xs={12} md={6}>
+                <FormField
+                  label="Medicine Name"
+                  name="name"
+                  type="text"
+                  value={form.formData.name || ''}
+                  onChange={form.handleChange}
+                  error={form.errors.name}
+                  required
+                  disabled={isDisabled}
+                />
+              </Col>
+              {/* Brand */}
+              <Col xs={12} md={6}>
+                <FormField
+                  label="Brand"
+                  name="brand"
+                  type="text"
+                  value={form.formData.brand || ''}
+                  onChange={form.handleChange}
+                  error={form.errors.brand}
+                  required
+                  disabled={isDisabled}
+                />
+              </Col>
+              {/* Unit */}
+              <Col xs={12} md={6}>
+                <FormField
+                  label="Unit"
+                  name="unit"
+                  type="text"
+                  value={form.formData.unit || ''}
+                  onChange={form.handleChange}
+                  error={form.errors.unit}
+                  required
+                  placeholder="e.g., tablets, capsules, ml"
+                  disabled={isDisabled}
+                />
+              </Col>
+              {/* Dosage - Multi-tag input */}
+              <Col xs={12}>
+                <DosageInput
+                  values={form.formData.dosage || []}
+                  onChange={(newDosages) => form.setFieldValue('dosage', newDosages)}
+                  disabled={isDisabled}
+                />
+                {form.errors.dosage && (
+                  <div className="text-danger" style={{ fontSize: '0.875rem', marginTop: '-0.5rem' }}>
+                    {form.errors.dosage}
+                  </div>
+                )}
+              </Col>
+              {/* Description */}
+              <Col xs={12}>
+                <FormField
+                  label="Description"
+                  name="description"
+                  type="textarea"
+                  value={form.formData.description || ''}
+                  onChange={form.handleChange}
+                  error={form.errors.description}
+                  rows={2}
+                  disabled={isDisabled}
+                />
+              </Col>
+              {/* Details - Rich text */}
+              <Col xs={12}>
+                <RichTextEditor
+                  label="Details (Meta - Not shown in table)"
+                  value={form.formData.details || ''}
+                  onChange={(value) => form.handleChange({ target: { name: 'details', value } })}
+                  error={form.errors.details}
+                  placeholder="Additional details..."
+                  height="150px"
+                  id="details"
+                />
+              </Col>
+            </Row>
+          </EntityForm>
+        </Col>
+      </Row>
+    </Container>
+  )
+}
+
+export default MedicineDetail

--- a/src/pages/Medicines.jsx
+++ b/src/pages/Medicines.jsx
@@ -1,210 +1,115 @@
-import { useSelector } from 'react-redux'
-import { Container, Row, Col, Button } from 'react-bootstrap'
-import { FaPills, FaEdit, FaTrash } from 'react-icons/fa'
-import { fetchMedicines, addMedicine, updateMedicine, deleteMedicine, selectAllMedicines } from '../store/medicinesSlice'
-import { useCRUD } from '../hooks'
-import { useNotification } from '../context'
+import { useEffect } from 'react'
+import { useSelector, useDispatch } from 'react-redux'
+import { useNavigate } from 'react-router-dom'
+import { Container, Row, Col } from 'react-bootstrap'
+import { FaPills } from 'react-icons/fa'
+import { fetchMedicines, selectAllMedicines } from '../store/medicinesSlice'
 import { PageHeader } from '../components/ui'
-import { EnhancedCRUDTable, CRUDModal } from '../components/crud'
-import { PermissionGate, usePermission } from '../components/auth/PermissionGate'
-
-// Form field configuration
-const MEDICINE_FIELDS = [
-  { name: 'code', label: 'Medicine Code', type: 'text', required: true, colSize: 6, placeholder: 'e.g., MED001' },
-  { name: 'name', label: 'Medicine Name', type: 'text', required: true, colSize: 6 },
-  { name: 'brand', label: 'Brand', type: 'text', required: true, colSize: 6 },
-  { name: 'dosage', label: 'Dosage', type: 'text', required: true, colSize: 6, placeholder: 'e.g., 20mg, 500mg, 10ml' },
-  { name: 'unit', label: 'Unit', type: 'text', required: true, colSize: 6, placeholder: 'e.g., tablets, capsules, ml' },
-  { name: 'description', label: 'Description', type: 'textarea', required: false, colSize: 12, rows: 2 },
-  { name: 'details', label: 'Details (Meta - Not shown in table)', type: 'richtext', required: false, colSize: 12, height: '150px' },
-];
-
-// Table column configuration - details field excluded from table
-const TABLE_COLUMNS = [
-  {
-    key: 'code',
-    label: 'Code',
-    render: (value) => (
-      <strong style={{
-        color: '#0891B2',
-        whiteSpace: 'nowrap',
-        fontSize: 'clamp(0.85rem, 2vw, 1rem)'
-      }}>
-        {value}
-      </strong>
-    )
-  },
-  {
-    key: 'name',
-    label: 'Medicine Name',
-    render: (value) => (
-      <strong style={{
-        whiteSpace: 'pre-wrap',
-        wordWrap: 'break-word',
-        maxWidth: window.innerWidth < 768 ? '120px' : '200px',
-        display: 'inline-block',
-        fontSize: 'clamp(0.85rem, 2vw, 1rem)'
-      }}>
-        {value}
-      </strong>
-    )
-  },
-  {
-    key: 'brand',
-    label: 'Brand',
-    render: (value) => (
-      <span style={{
-        whiteSpace: 'nowrap',
-        fontSize: 'clamp(0.85rem, 2vw, 1rem)'
-      }}>
-        {value}
-      </span>
-    )
-  },
-  {
-    key: 'dosage',
-    label: 'Dosage',
-    render: (value) => (
-      <span style={{
-        whiteSpace: 'nowrap',
-        fontSize: 'clamp(0.85rem, 2vw, 1rem)',
-        color: '#059669',
-        fontWeight: '600'
-      }}>
-        {value}
-      </span>
-    )
-  },
-  {
-    key: 'unit',
-    label: 'Unit',
-    render: (value) => (
-      <span style={{
-        whiteSpace: 'nowrap',
-        fontSize: 'clamp(0.85rem, 2vw, 1rem)'
-      }}>
-        {value}
-      </span>
-    )
-  },
-  {
-    key: 'description',
-    label: 'Description',
-    render: (value) => (
-      <div style={{
-        whiteSpace: 'pre-wrap',
-        wordWrap: 'break-word',
-        maxWidth: window.innerWidth < 768 ? '120px' : '250px',
-        fontSize: 'clamp(0.85rem, 2vw, 0.95rem)',
-        lineHeight: '1.4'
-      }}>
-        {value || '-'}
-      </div>
-    )
-  },
-];
+import { EnhancedCRUDTable } from '../components/crud'
+import { usePermission } from '../components/auth/PermissionGate'
 
 function Medicines() {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
   const medicines = useSelector(selectAllMedicines);
   const { loading, error } = useSelector(state => state.medicines);
-  const { success, error: showError } = useNotification();
   const { checkPermission } = usePermission();
 
-  // Custom validation for unique code field
-  const validateForm = (data, isEdit, editingId) => {
-    const errors = {};
+  useEffect(() => {
+    dispatch(fetchMedicines());
+  }, [dispatch]);
 
-    // Check if code is unique
-    const codeExists = medicines.find(medicine =>
-      medicine.code?.toLowerCase() === data.code?.toLowerCase() &&
-      medicine.id !== editingId
-    );
-
-    if (codeExists) {
-      errors.code = `Medicine code "${data.code}" already exists. Please use a unique code.`;
-    }
-
-    return errors;
-  };
-
-  // Custom hook handles ALL CRUD operations, modal, and form state
-  const {
-    showModal,
-    isEditing,
-    formData,
-    formErrors,
-    isSubmitting,
-    handleChange,
-    handleOpen,
-    handleClose,
-    handleSubmit,
-    handleDelete,
-  } = useCRUD({
-    fetchAction: fetchMedicines,
-    addAction: addMedicine,
-    updateAction: updateMedicine,
-    deleteAction: deleteMedicine,
-    initialFormState: {
-      code: '',
-      name: '',
-      brand: '',
-      dosage: '',
-      unit: '',
-      description: '',
-      details: '',
-    },
-    customValidation: validateForm,
-    onSuccess: (action) => {
-      success(`Medicine ${action} successfully!`);
-    },
-    onError: (err) => {
-      showError(err.message || 'Operation failed');
-    },
-  });
-
-  // Custom render actions with permissions
-  const renderActions = (item) => (
-    <>
-      <PermissionGate resource="medicines" action="edit">
-        <Button
-          size="sm"
-          onClick={() => handleOpen(item)}
-          className="me-2"
+  const TABLE_COLUMNS = [
+    {
+      key: 'code',
+      label: 'Code',
+      render: (value, item) => (
+        <strong
+          onClick={() => navigate(`/medicines/${item.id}`)}
           style={{
-            backgroundColor: 'transparent',
-            border: '2px solid #0891B2',
-            color: '#0891B2'
+            color: '#0891B2',
+            whiteSpace: 'nowrap',
+            fontSize: 'clamp(0.85rem, 2vw, 1rem)',
+            cursor: 'pointer',
+            textDecoration: 'none'
           }}
+          onMouseEnter={(e) => e.target.style.textDecoration = 'underline'}
+          onMouseLeave={(e) => e.target.style.textDecoration = 'none'}
         >
-          <FaEdit className="me-1" />
-          Edit
-        </Button>
-      </PermissionGate>
-      <PermissionGate resource="medicines" action="delete">
-        <Button
-          size="sm"
-          onClick={() => handleDelete(item.id, 'Are you sure you want to delete this medicine?')}
-          style={{
-            backgroundColor: 'transparent',
-            border: '2px solid #0aa2c0',
-            color: '#0aa2c0'
-          }}
-        >
-          <FaTrash className="me-1" />
-          Delete
-        </Button>
-      </PermissionGate>
-    </>
-  );
-
-  const hasEditOrDelete = checkPermission('medicines', 'edit') || checkPermission('medicines', 'delete');
+          {value}
+        </strong>
+      )
+    },
+    {
+      key: 'name',
+      label: 'Medicine Name',
+      render: (value) => (
+        <strong style={{
+          whiteSpace: 'pre-wrap',
+          wordWrap: 'break-word',
+          maxWidth: window.innerWidth < 768 ? '120px' : '200px',
+          display: 'inline-block',
+          fontSize: 'clamp(0.85rem, 2vw, 1rem)'
+        }}>
+          {value}
+        </strong>
+      )
+    },
+    {
+      key: 'brand',
+      label: 'Brand',
+      render: (value) => (
+        <span style={{
+          whiteSpace: 'nowrap',
+          fontSize: 'clamp(0.85rem, 2vw, 1rem)'
+        }}>
+          {value}
+        </span>
+      )
+    },
+    {
+      key: 'dosage',
+      label: 'Dosage',
+      render: (value) => {
+        const dosages = Array.isArray(value) ? value : (value ? [value] : [])
+        return dosages.length > 0 ? dosages.join(', ') : '-'
+      }
+    },
+    {
+      key: 'unit',
+      label: 'Unit',
+      render: (value) => (
+        <span style={{
+          whiteSpace: 'nowrap',
+          fontSize: 'clamp(0.85rem, 2vw, 1rem)'
+        }}>
+          {value}
+        </span>
+      )
+    },
+    {
+      key: 'description',
+      label: 'Description',
+      render: (value) => (
+        <div style={{
+          whiteSpace: 'pre-wrap',
+          wordWrap: 'break-word',
+          maxWidth: window.innerWidth < 768 ? '120px' : '250px',
+          fontSize: 'clamp(0.85rem, 2vw, 0.95rem)',
+          lineHeight: '1.4'
+        }}>
+          {value || '-'}
+        </div>
+      )
+    },
+  ];
 
   return (
     <Container fluid className="p-3 p-md-4">
       <PageHeader
         icon={FaPills}
         title="Medicines Management"
-        onAddClick={checkPermission('medicines', 'create') ? () => handleOpen() : undefined}
+        onAddClick={checkPermission('medicines', 'create') ? () => navigate('/medicines/new') : undefined}
         addButtonText="Add New Medicine"
         showAddButton={checkPermission('medicines', 'create')}
       />
@@ -214,7 +119,6 @@ function Medicines() {
           <EnhancedCRUDTable
             data={medicines}
             columns={TABLE_COLUMNS}
-            renderActions={hasEditOrDelete ? renderActions : undefined}
             loading={loading}
             error={error}
             emptyMessage="No medicines available"
@@ -223,20 +127,6 @@ function Medicines() {
           />
         </Col>
       </Row>
-
-      <CRUDModal
-        show={showModal}
-        title={isEditing ? 'Edit Medicine' : 'Add New Medicine'}
-        isEditing={isEditing}
-        fields={MEDICINE_FIELDS}
-        formData={formData}
-        formErrors={formErrors}
-        onFormChange={handleChange}
-        onSubmit={handleSubmit}
-        onClose={handleClose}
-        loading={isSubmitting}
-        size="xl"
-      />
     </Container>
   );
 }

--- a/src/pages/PatientDetail.jsx
+++ b/src/pages/PatientDetail.jsx
@@ -1,38 +1,149 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { useSelector } from 'react-redux'
-import { Container, Row, Col, Card, Button, Table, Badge, Collapse } from 'react-bootstrap'
+import { useSelector, useDispatch } from 'react-redux'
+import { Container, Row, Col, Card, Button, Table, Badge, Collapse, Form } from 'react-bootstrap'
 import { FaArrowLeft, FaUserInjured, FaMale, FaFemale, FaUser, FaWeight, FaRulerVertical, FaChevronDown, FaChevronRight } from 'react-icons/fa'
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts'
-import { selectAllPatients } from '../store/patientsSlice'
+import { selectAllPatients, addPatient, updatePatient, deletePatient, fetchPatients } from '../store/patientsSlice'
 import { selectAllCheckups } from '../store/checkupsSlice'
 import { selectAllTests } from '../store/testsSlice'
+import { useForm } from '../hooks'
+import { useNotification } from '../context'
+import { EntityForm } from '../components/crud'
+import { PermissionGate, usePermission } from '../components/auth/PermissionGate'
+
+// Form field configuration (without gender - handled separately via children)
+const PATIENT_FIELDS = [
+  { name: 'name', label: 'Patient Name', type: 'text', required: true, colSize: 6 },
+  { name: 'age', label: 'Age', type: 'number', required: true, colSize: 6 },
+  { name: 'mobile', label: 'Mobile', type: 'tel', required: true, colSize: 6 },
+  { name: 'email', label: 'Email', type: 'email', required: false, colSize: 6 },
+  { name: 'address', label: 'Address', type: 'textarea', required: true, colSize: 12, rows: 2 },
+];
+
+const INITIAL_FORM = {
+  name: '',
+  age: '',
+  gender: 'Male',
+  mobile: '',
+  address: '',
+  email: '',
+};
+
+// Custom Gender Icon Selector Component
+const GenderIconSelector = ({ value, onChange, name, disabled }) => {
+  const genderOptions = [
+    { value: 'Male', icon: FaMale, color: '#0891B2' },
+    { value: 'Female', icon: FaFemale, color: '#06B6D4' },
+    { value: 'Other', icon: FaUser, color: '#0aa2c0' }
+  ]
+
+  return (
+    <Form.Group className="mb-3">
+      <Form.Label>
+        Gender <span className="text-danger ms-1">*</span>
+      </Form.Label>
+      <div className="d-flex gap-3">
+        {genderOptions.map((option) => {
+          const Icon = option.icon
+          const isSelected = value === option.value
+          return (
+            <Icon
+              key={option.value}
+              size={28}
+              onClick={() => !disabled && onChange({ target: { name, value: option.value } })}
+              style={{
+                cursor: disabled ? 'not-allowed' : 'pointer',
+                opacity: disabled ? 0.6 : isSelected ? 1 : 0.4,
+                transition: 'opacity 0.2s',
+                color: isSelected ? option.color : '#9ca3af'
+              }}
+            />
+          )
+        })}
+      </div>
+    </Form.Group>
+  )
+}
 
 function PatientDetail() {
   const { id } = useParams()
   const navigate = useNavigate()
+  const dispatch = useDispatch()
   const patients = useSelector(selectAllPatients)
   const checkups = useSelector(selectAllCheckups)
   const tests = useSelector(selectAllTests)
+  const { loading } = useSelector(state => state.patients)
+  const { success, error: showError } = useNotification()
+  const { checkPermission } = usePermission()
 
-  const [patient, setPatient] = useState(null)
+  const isNew = id === 'new'
+  const patient = isNew ? null : patients.find(p => p.id === id)
+
   const [patientCheckups, setPatientCheckups] = useState([])
   const [chartData, setChartData] = useState([])
   const [expandedRows, setExpandedRows] = useState({})
 
-  useEffect(() => {
-    // Find the patient
-    const foundPatient = patients.find(p => p.id === id)
-    setPatient(foundPatient)
+  const handleFormSubmit = useCallback(async (formData) => {
+    const dataToSubmit = {
+      ...formData,
+      age: parseInt(formData.age),
+    }
 
-    // Get all checkups for this patient
+    try {
+      if (isNew) {
+        const result = await dispatch(addPatient(dataToSubmit))
+        if (result.type.includes('rejected')) {
+          throw new Error(result.payload || 'Failed to add patient')
+        }
+        success('Patient added successfully!')
+        navigate(`/patients/${result.payload.id}`, { replace: true })
+      } else {
+        const result = await dispatch(updatePatient({ id, ...dataToSubmit }))
+        if (result.type.includes('rejected')) {
+          throw new Error(result.payload || 'Failed to update patient')
+        }
+        success('Patient updated successfully!')
+      }
+    } catch (err) {
+      showError(err.message || 'Operation failed')
+      throw err
+    }
+  }, [isNew, id, dispatch, navigate, success, showError])
+
+  const form = useForm(INITIAL_FORM, handleFormSubmit)
+
+  // Load patient data into form when editing
+  useEffect(() => {
+    if (patient) {
+      form.resetTo({
+        name: patient.name || '',
+        age: patient.age?.toString() || '',
+        gender: patient.gender || 'Male',
+        mobile: patient.mobile || '',
+        address: patient.address || '',
+        email: patient.email || '',
+      })
+    }
+  }, [patient?.id]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Fetch patients if store is empty
+  useEffect(() => {
+    if (patients.length === 0) {
+      dispatch(fetchPatients())
+    }
+  }, [dispatch, patients.length])
+
+  // Build checkup history data
+  useEffect(() => {
+    if (isNew || !id) return
+
     const checkupsForPatient = checkups
       .filter(c => c.patientId === id)
       .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp))
 
     setPatientCheckups(checkupsForPatient)
 
-    // Prepare chart data (reverse order for chronological display)
     const data = checkupsForPatient
       .filter(c => c.weight || c.height)
       .reverse()
@@ -44,9 +155,31 @@ function PatientDetail() {
       }))
 
     setChartData(data)
-  }, [id, patients, checkups])
+  }, [id, isNew, checkups])
 
-  if (!patient) {
+  const handleDelete = async () => {
+    if (!window.confirm('Are you sure you want to delete this patient?')) return
+    try {
+      const result = await dispatch(deletePatient(id))
+      if (result.type.includes('rejected')) {
+        throw new Error(result.payload || 'Failed to delete patient')
+      }
+      success('Patient deleted successfully!')
+      navigate('/patients')
+    } catch (err) {
+      showError(err.message || 'Delete failed')
+    }
+  }
+
+  const toggleRow = (checkupId) => {
+    setExpandedRows(prev => ({
+      ...prev,
+      [checkupId]: !prev[checkupId]
+    }))
+  }
+
+  // Not found (only for edit mode, not new)
+  if (!isNew && !patient && patients.length > 0) {
     return (
       <Container fluid className="p-3 p-md-4">
         <Card>
@@ -69,291 +202,322 @@ function PatientDetail() {
     )
   }
 
-  const getGenderIcon = () => {
-    if (patient.gender === 'Male') return <FaMale style={{ color: '#0891B2' }} size={24} />
-    if (patient.gender === 'Female') return <FaFemale style={{ color: '#06B6D4' }} size={24} />
-    return <FaUser style={{ color: '#0aa2c0' }} size={24} />
-  }
-
-  const toggleRow = (checkupId) => {
-    setExpandedRows(prev => ({
-      ...prev,
-      [checkupId]: !prev[checkupId]
-    }))
-  }
+  const canEdit = checkPermission('patients', isNew ? 'create' : 'edit')
+  const canDelete = !isNew && checkPermission('patients', 'delete')
 
   return (
     <Container fluid className="p-3 p-md-4">
       {/* Header */}
       <Row className="mb-4">
         <Col>
-          <Button
-            onClick={() => navigate('/patients')}
-            size="sm"
-            className="mb-3"
-            style={{
-              backgroundColor: 'transparent',
-              border: '2px solid #0891B2',
-              color: '#0891B2'
-            }}
-          >
-            <FaArrowLeft className="me-2" />
-            Back to Patients
-          </Button>
-          <h2>
+          <h2 style={{ fontSize: 'clamp(1.2rem, 3vw, 1.75rem)' }}>
             <FaUserInjured className="me-2" style={{ color: '#0891B2' }} />
-            Patient Details
+            {isNew ? 'Add New Patient' : 'Patient Details'}
           </h2>
         </Col>
       </Row>
 
-      {/* Patient Details and Graph Section */}
+      {/* Patient Form */}
       <Row className="mb-4">
-        {/* Personal Details */}
-        <Col xs={12} lg={4} className="mb-3 mb-lg-0">
-          <Card className="h-100 shadow-sm">
-            <Card.Header style={{ backgroundColor: '#06B6D4', color: 'white' }}>
-              <h5 className="mb-0">Personal Information</h5>
-            </Card.Header>
-            <Card.Body>
-              <div className="d-flex align-items-center mb-3">
-                {getGenderIcon()}
-                <h4 className="mb-0 ms-3">{patient.name}</h4>
-              </div>
-
-              <div className="mb-2">
-                <strong>Age:</strong> {patient.age} years
-              </div>
-              <div className="mb-2">
-                <strong>Gender:</strong> {patient.gender}
-              </div>
-              <div className="mb-2">
-                <strong>Mobile:</strong> {patient.mobile}
-              </div>
-              {patient.email && (
-                <div className="mb-2">
-                  <strong>Email:</strong> {patient.email}
-                </div>
-              )}
-              <div className="mb-2">
-                <strong>Address:</strong> {patient.address}
-              </div>
-
-              <hr />
-
-              <div className="mb-2">
-                <strong>Total Checkups:</strong>{' '}
-                <Badge style={{ backgroundColor: '#06B6D4', color: 'white' }}>
-                  {patientCheckups.length}
-                </Badge>
-              </div>
-
-              {chartData.length > 0 && (
-                <>
-                  <div className="mb-2">
-                    <FaWeight className="me-2" style={{ color: '#0891B2' }} />
-                    <strong>Latest Weight:</strong> {chartData[chartData.length - 1].weight || 'N/A'} kg
-                  </div>
-                  <div className="mb-2">
-                    <FaRulerVertical className="me-2" style={{ color: '#06B6D4' }} />
-                    <strong>Latest Height:</strong> {chartData[chartData.length - 1].height || 'N/A'} cm
-                  </div>
-                </>
-              )}
-            </Card.Body>
-          </Card>
-        </Col>
-
-        {/* Height/Weight Graph */}
-        <Col xs={12} lg={8}>
-          <Card className="shadow-sm">
-            <Card.Header style={{ backgroundColor: '#06B6D4', color: 'white' }}>
-              <h5 className="mb-0">Height & Weight Tracking</h5>
-            </Card.Header>
-            <Card.Body>
-              {chartData.length > 0 ? (
-                <ResponsiveContainer width="100%" height={300}>
-                  <LineChart data={chartData}>
-                    <CartesianGrid strokeDasharray="3 3" />
-                    <XAxis
-                      dataKey="date"
-                      tick={{ fontSize: 12 }}
-                      angle={-45}
-                      textAnchor="end"
-                      height={80}
+        <Col>
+          <EntityForm
+            title={isNew ? 'New Patient Information' : 'Personal Information'}
+            fields={PATIENT_FIELDS}
+            formData={form.formData}
+            formErrors={form.errors}
+            onFormChange={form.handleChange}
+            onSubmit={form.handleSubmit}
+            onCancel={() => navigate('/patients')}
+            onDelete={canDelete ? handleDelete : undefined}
+            loading={form.isSubmitting || loading}
+            isEditing={!isNew}
+          >
+            <Row className="g-3">
+              {PATIENT_FIELDS.slice(0, 2).map((field) => (
+                <Col key={field.name} xs={12} md={field.colSize || 6}>
+                  <Form.Group className="mb-3">
+                    <Form.Label>
+                      {field.label}
+                      {field.required && <span className="text-danger ms-1">*</span>}
+                    </Form.Label>
+                    <Form.Control
+                      type={field.type}
+                      name={field.name}
+                      value={form.formData[field.name] || ''}
+                      onChange={form.handleChange}
+                      required={field.required}
+                      disabled={form.isSubmitting || !canEdit}
                     />
-                    <YAxis yAxisId="left" label={{ value: 'Weight (kg)', angle: -90, position: 'insideLeft' }} />
-                    <YAxis yAxisId="right" orientation="right" label={{ value: 'Height (cm)', angle: 90, position: 'insideRight' }} />
-                    <Tooltip />
-                    <Legend />
-                    <Line
-                      yAxisId="left"
-                      type="monotone"
-                      dataKey="weight"
-                      stroke="#0891B2"
-                      strokeWidth={2}
-                      dot={{ fill: '#0891B2', r: 4 }}
-                      name="Weight (kg)"
-                      connectNulls
-                    />
-                    <Line
-                      yAxisId="right"
-                      type="monotone"
-                      dataKey="height"
-                      stroke="#06B6D4"
-                      strokeWidth={2}
-                      dot={{ fill: '#06B6D4', r: 4 }}
-                      name="Height (cm)"
-                      connectNulls
-                    />
-                  </LineChart>
-                </ResponsiveContainer>
-              ) : (
-                <div className="text-center py-5 text-muted">
-                  <FaWeight size={48} className="mb-3" style={{ color: '#cbd5e1' }} />
-                  <p>No height/weight data recorded yet</p>
-                </div>
-              )}
-            </Card.Body>
-          </Card>
+                  </Form.Group>
+                </Col>
+              ))}
+              <Col xs={12}>
+                <GenderIconSelector
+                  value={form.formData.gender}
+                  onChange={form.handleChange}
+                  name="gender"
+                  disabled={form.isSubmitting || !canEdit}
+                />
+              </Col>
+              {PATIENT_FIELDS.slice(2).map((field) => (
+                <Col key={field.name} xs={12} md={field.colSize || 6}>
+                  <Form.Group className="mb-3">
+                    <Form.Label>
+                      {field.label}
+                      {field.required && <span className="text-danger ms-1">*</span>}
+                    </Form.Label>
+                    {field.type === 'textarea' ? (
+                      <Form.Control
+                        as="textarea"
+                        rows={field.rows || 3}
+                        name={field.name}
+                        value={form.formData[field.name] || ''}
+                        onChange={form.handleChange}
+                        required={field.required}
+                        disabled={form.isSubmitting || !canEdit}
+                      />
+                    ) : (
+                      <Form.Control
+                        type={field.type}
+                        name={field.name}
+                        value={form.formData[field.name] || ''}
+                        onChange={form.handleChange}
+                        required={field.required}
+                        disabled={form.isSubmitting || !canEdit}
+                      />
+                    )}
+                  </Form.Group>
+                </Col>
+              ))}
+            </Row>
+          </EntityForm>
         </Col>
       </Row>
 
-      {/* Checkup History Section */}
-      <Row>
-        <Col>
-          <Card className="shadow-sm">
-            <Card.Header style={{ backgroundColor: '#06B6D4', color: 'white' }}>
-              <h5 className="mb-0">Checkup History</h5>
-            </Card.Header>
-            <Card.Body className="p-0">
-              {patientCheckups.length === 0 ? (
-                <div className="text-center py-4 text-muted">
-                  No checkups recorded yet
-                </div>
-              ) : (
-                <div className="table-responsive">
-                  <Table hover className="mb-0 table-mobile-responsive">
-                    <thead style={{ backgroundColor: '#f1f5f9' }}>
-                      <tr>
-                        <th style={{ width: '5%' }}></th>
-                        <th style={{ width: '20%' }}>Date</th>
-                        <th style={{ width: '15%' }}>Tests Count</th>
-                        <th style={{ width: '60%' }}>General Notes</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {patientCheckups.map((checkup) => {
-                        const isExpanded = expandedRows[checkup.id]
-                        return (
-                          <>
-                            {/* Main Row - Clickable */}
-                            <tr
-                              key={checkup.id}
-                              onClick={() => toggleRow(checkup.id)}
-                              style={{
-                                cursor: 'pointer',
-                                backgroundColor: isExpanded ? '#f0f9ff' : 'transparent'
-                              }}
-                            >
-                              <td data-label="" className="text-center">
-                                {isExpanded ? (
-                                  <FaChevronDown style={{ color: '#0891B2' }} />
-                                ) : (
-                                  <FaChevronRight style={{ color: '#94a3b8' }} />
-                                )}
-                              </td>
-                              <td data-label="Date">
-                                <strong style={{ color: '#0891B2' }}>
-                                  {new Date(checkup.timestamp).toLocaleDateString()}
-                                </strong>
-                                <br />
-                                <small className="text-muted">
-                                  {new Date(checkup.timestamp).toLocaleTimeString([], {
-                                    hour: '2-digit',
-                                    minute: '2-digit'
-                                  })}
-                                </small>
-                              </td>
-                              <td data-label="Tests">
-                                <Badge
+      {/* Checkup history and charts only shown in edit mode */}
+      {!isNew && patient && (
+        <>
+          {/* Patient Stats and Graph Section */}
+          <Row className="mb-4">
+            {/* Stats */}
+            <Col xs={12} lg={4} className="mb-3 mb-lg-0">
+              <Card className="h-100 shadow-sm">
+                <Card.Header style={{ backgroundColor: '#06B6D4', color: 'white' }}>
+                  <h5 className="mb-0">Summary</h5>
+                </Card.Header>
+                <Card.Body>
+                  <div className="mb-2">
+                    <strong>Total Checkups:</strong>{' '}
+                    <Badge style={{ backgroundColor: '#06B6D4', color: 'white' }}>
+                      {patientCheckups.length}
+                    </Badge>
+                  </div>
+
+                  {chartData.length > 0 && (
+                    <>
+                      <div className="mb-2">
+                        <FaWeight className="me-2" style={{ color: '#0891B2' }} />
+                        <strong>Latest Weight:</strong> {chartData[chartData.length - 1].weight || 'N/A'} kg
+                      </div>
+                      <div className="mb-2">
+                        <FaRulerVertical className="me-2" style={{ color: '#06B6D4' }} />
+                        <strong>Latest Height:</strong> {chartData[chartData.length - 1].height || 'N/A'} cm
+                      </div>
+                    </>
+                  )}
+                </Card.Body>
+              </Card>
+            </Col>
+
+            {/* Height/Weight Graph */}
+            <Col xs={12} lg={8}>
+              <Card className="shadow-sm">
+                <Card.Header style={{ backgroundColor: '#06B6D4', color: 'white' }}>
+                  <h5 className="mb-0">Height & Weight Tracking</h5>
+                </Card.Header>
+                <Card.Body>
+                  {chartData.length > 0 ? (
+                    <ResponsiveContainer width="100%" height={300}>
+                      <LineChart data={chartData}>
+                        <CartesianGrid strokeDasharray="3 3" />
+                        <XAxis
+                          dataKey="date"
+                          tick={{ fontSize: 12 }}
+                          angle={-45}
+                          textAnchor="end"
+                          height={80}
+                        />
+                        <YAxis yAxisId="left" label={{ value: 'Weight (kg)', angle: -90, position: 'insideLeft' }} />
+                        <YAxis yAxisId="right" orientation="right" label={{ value: 'Height (cm)', angle: 90, position: 'insideRight' }} />
+                        <Tooltip />
+                        <Legend />
+                        <Line
+                          yAxisId="left"
+                          type="monotone"
+                          dataKey="weight"
+                          stroke="#0891B2"
+                          strokeWidth={2}
+                          dot={{ fill: '#0891B2', r: 4 }}
+                          name="Weight (kg)"
+                          connectNulls
+                        />
+                        <Line
+                          yAxisId="right"
+                          type="monotone"
+                          dataKey="height"
+                          stroke="#06B6D4"
+                          strokeWidth={2}
+                          dot={{ fill: '#06B6D4', r: 4 }}
+                          name="Height (cm)"
+                          connectNulls
+                        />
+                      </LineChart>
+                    </ResponsiveContainer>
+                  ) : (
+                    <div className="text-center py-5 text-muted">
+                      <FaWeight size={48} className="mb-3" style={{ color: '#cbd5e1' }} />
+                      <p>No height/weight data recorded yet</p>
+                    </div>
+                  )}
+                </Card.Body>
+              </Card>
+            </Col>
+          </Row>
+
+          {/* Checkup History Section */}
+          <Row>
+            <Col>
+              <Card className="shadow-sm">
+                <Card.Header style={{ backgroundColor: '#06B6D4', color: 'white' }}>
+                  <h5 className="mb-0">Checkup History</h5>
+                </Card.Header>
+                <Card.Body className="p-0">
+                  {patientCheckups.length === 0 ? (
+                    <div className="text-center py-4 text-muted">
+                      No checkups recorded yet
+                    </div>
+                  ) : (
+                    <div className="table-responsive">
+                      <Table hover className="mb-0 table-mobile-responsive">
+                        <thead style={{ backgroundColor: '#f1f5f9' }}>
+                          <tr>
+                            <th style={{ width: '5%' }}></th>
+                            <th style={{ width: '20%' }}>Date</th>
+                            <th style={{ width: '15%' }}>Tests Count</th>
+                            <th style={{ width: '60%' }}>General Notes</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {patientCheckups.map((checkup) => {
+                            const isExpanded = expandedRows[checkup.id]
+                            return (
+                              <React.Fragment key={checkup.id}>
+                                <tr
+                                  onClick={() => toggleRow(checkup.id)}
                                   style={{
-                                    backgroundColor: '#0891B2',
-                                    color: 'white',
-                                    fontSize: '0.85rem',
-                                    padding: '0.4rem 0.8rem'
+                                    cursor: 'pointer',
+                                    backgroundColor: isExpanded ? '#f0f9ff' : 'transparent'
                                   }}
                                 >
-                                  {checkup.tests.length} test{checkup.tests.length !== 1 ? 's' : ''}
-                                </Badge>
-                              </td>
-                              <td data-label="Notes">
-                                {checkup.notes ? (
-                                  <div style={{ fontSize: '0.9rem' }}>{checkup.notes}</div>
-                                ) : (
-                                  <span className="text-muted">-</span>
-                                )}
-                              </td>
-                            </tr>
+                                  <td data-label="" className="text-center">
+                                    {isExpanded ? (
+                                      <FaChevronDown style={{ color: '#0891B2' }} />
+                                    ) : (
+                                      <FaChevronRight style={{ color: '#94a3b8' }} />
+                                    )}
+                                  </td>
+                                  <td data-label="Date">
+                                    <strong style={{ color: '#0891B2' }}>
+                                      {new Date(checkup.timestamp).toLocaleDateString()}
+                                    </strong>
+                                    <br />
+                                    <small className="text-muted">
+                                      {new Date(checkup.timestamp).toLocaleTimeString([], {
+                                        hour: '2-digit',
+                                        minute: '2-digit'
+                                      })}
+                                    </small>
+                                  </td>
+                                  <td data-label="Tests">
+                                    <Badge
+                                      style={{
+                                        backgroundColor: '#0891B2',
+                                        color: 'white',
+                                        fontSize: '0.85rem',
+                                        padding: '0.4rem 0.8rem'
+                                      }}
+                                    >
+                                      {checkup.tests.length} test{checkup.tests.length !== 1 ? 's' : ''}
+                                    </Badge>
+                                  </td>
+                                  <td data-label="Notes">
+                                    {checkup.notes ? (
+                                      <div style={{ fontSize: '0.9rem' }}>{checkup.notes}</div>
+                                    ) : (
+                                      <span className="text-muted">-</span>
+                                    )}
+                                  </td>
+                                </tr>
 
-                            {/* Expanded Row - Tests Table */}
-                            <tr>
-                              <td colSpan="4" style={{ padding: 0, border: 'none' }}>
-                                <Collapse in={isExpanded}>
-                                  <div>
-                                    <div style={{ backgroundColor: '#f8fafc', padding: '0.5rem 1rem' }}>
-                                      <Table
-                                        size="sm"
-                                        className="mb-0 table-mobile-responsive"
-                                        style={{ backgroundColor: 'white' }}
-                                      >
-                                        <thead style={{ backgroundColor: '#e0f2fe' }}>
-                                          <tr>
-                                            <th style={{ width: '40%' }}>Test Name</th>
-                                            <th style={{ width: '60%' }}>Notes</th>
-                                          </tr>
-                                        </thead>
-                                        <tbody>
-                                          {checkup.tests.map((testItem) => {
-                                            const test = tests.find(t => t.id === testItem.testId)
-
-                                            return test ? (
-                                              <tr key={testItem.testId}>
-                                                <td data-label="Test Name">
-                                                  <strong style={{ color: '#0891B2' }}>
-                                                    {test.name}
-                                                  </strong>
-                                                </td>
-                                                <td data-label="Notes">
-                                                  {testItem.notes ? (
-                                                    <div style={{ fontSize: '0.85rem' }}>{testItem.notes}</div>
-                                                  ) : (
-                                                    <span className="text-muted" style={{ fontSize: '0.85rem' }}>
-                                                      No specific notes for this test
-                                                    </span>
-                                                  )}
-                                                </td>
+                                <tr>
+                                  <td colSpan="4" style={{ padding: 0, border: 'none' }}>
+                                    <Collapse in={isExpanded}>
+                                      <div>
+                                        <div style={{ backgroundColor: '#f8fafc', padding: '0.5rem 1rem' }}>
+                                          <Table
+                                            size="sm"
+                                            className="mb-0 table-mobile-responsive"
+                                            style={{ backgroundColor: 'white' }}
+                                          >
+                                            <thead style={{ backgroundColor: '#e0f2fe' }}>
+                                              <tr>
+                                                <th style={{ width: '40%' }}>Test Name</th>
+                                                <th style={{ width: '60%' }}>Notes</th>
                                               </tr>
-                                            ) : null
-                                          })}
-                                        </tbody>
-                                      </Table>
-                                    </div>
-                                  </div>
-                                </Collapse>
-                              </td>
-                            </tr>
-                          </>
-                        )
-                      })}
-                    </tbody>
-                  </Table>
-                </div>
-              )}
-            </Card.Body>
-          </Card>
-        </Col>
-      </Row>
+                                            </thead>
+                                            <tbody>
+                                              {checkup.tests.map((testItem) => {
+                                                const test = tests.find(t => t.id === testItem.testId)
+
+                                                return test ? (
+                                                  <tr key={testItem.testId}>
+                                                    <td data-label="Test Name">
+                                                      <strong style={{ color: '#0891B2' }}>
+                                                        {test.name}
+                                                      </strong>
+                                                    </td>
+                                                    <td data-label="Notes">
+                                                      {testItem.notes ? (
+                                                        <div style={{ fontSize: '0.85rem' }}>{testItem.notes}</div>
+                                                      ) : (
+                                                        <span className="text-muted" style={{ fontSize: '0.85rem' }}>
+                                                          No specific notes for this test
+                                                        </span>
+                                                      )}
+                                                    </td>
+                                                  </tr>
+                                                ) : null
+                                              })}
+                                            </tbody>
+                                          </Table>
+                                        </div>
+                                      </div>
+                                    </Collapse>
+                                  </td>
+                                </tr>
+                              </React.Fragment>
+                            )
+                          })}
+                        </tbody>
+                      </Table>
+                    </div>
+                  )}
+                </Card.Body>
+              </Card>
+            </Col>
+          </Row>
+        </>
+      )}
     </Container>
   )
 }

--- a/src/pages/Patients.jsx
+++ b/src/pages/Patients.jsx
@@ -1,67 +1,24 @@
-import { useSelector } from 'react-redux'
+import { useEffect } from 'react'
+import { useSelector, useDispatch } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
-import { Container, Row, Col, Form, Button, ButtonGroup } from 'react-bootstrap'
-import { FaUserInjured, FaMale, FaFemale, FaUser, FaEdit, FaTrash } from 'react-icons/fa'
-import { fetchPatients, addPatient, updatePatient, deletePatient, selectAllPatients } from '../store/patientsSlice'
-import { useCRUD } from '../hooks'
-import { useNotification } from '../context'
+import { Container, Row, Col } from 'react-bootstrap'
+import { FaUserInjured, FaMale, FaFemale, FaUser } from 'react-icons/fa'
+import { fetchPatients, selectAllPatients } from '../store/patientsSlice'
 import { PageHeader } from '../components/ui'
-import { EnhancedCRUDTable, CRUDModal } from '../components/crud'
-import { PermissionGate, usePermission } from '../components/auth/PermissionGate'
-
-// Custom Gender Icon Selector Component
-const GenderIconSelector = ({ value, onChange, name, disabled }) => {
-  const genderOptions = [
-    { value: 'Male', icon: FaMale, color: '#0891B2' },
-    { value: 'Female', icon: FaFemale, color: '#06B6D4' },
-    { value: 'Other', icon: FaUser, color: '#0aa2c0' }
-  ]
-
-  return (
-    <Form.Group className="mb-3">
-      <Form.Label>
-        Gender <span className="text-danger ms-1">*</span>
-      </Form.Label>
-      <div className="d-flex gap-3">
-        {genderOptions.map((option) => {
-          const Icon = option.icon
-          const isSelected = value === option.value
-          return (
-            <Icon
-              key={option.value}
-              size={28}
-              onClick={() => !disabled && onChange({ target: { name, value: option.value } })}
-              style={{
-                cursor: disabled ? 'not-allowed' : 'pointer',
-                opacity: disabled ? 0.6 : isSelected ? 1 : 0.4,
-                transition: 'opacity 0.2s',
-                color: isSelected ? option.color : '#9ca3af'
-              }}
-            />
-          )
-        })}
-      </div>
-    </Form.Group>
-  )
-}
-
-// Form field configuration (without gender - handled separately)
-const PATIENT_FIELDS = [
-  { name: 'name', label: 'Patient Name', type: 'text', required: true, colSize: 6 },
-  { name: 'age', label: 'Age', type: 'number', required: true, colSize: 6 },
-  { name: 'mobile', label: 'Mobile', type: 'tel', required: true, colSize: 6 },
-  { name: 'email', label: 'Email', type: 'email', required: false, colSize: 6 },
-  { name: 'address', label: 'Address', type: 'textarea', required: true, colSize: 12, rows: 2 },
-];
+import { EnhancedCRUDTable } from '../components/crud'
+import { usePermission } from '../components/auth/PermissionGate'
 
 function Patients() {
+  const dispatch = useDispatch();
   const navigate = useNavigate();
   const patients = useSelector(selectAllPatients);
   const { loading, error } = useSelector(state => state.patients);
-  const { success, error: showError } = useNotification();
   const { checkPermission } = usePermission();
 
-  // Table column configuration
+  useEffect(() => {
+    dispatch(fetchPatients());
+  }, [dispatch]);
+
   const TABLE_COLUMNS = [
     {
       key: 'gender',
@@ -99,86 +56,12 @@ function Patients() {
     { key: 'address', label: 'Address' },
   ];
 
-  // Custom hook handles ALL CRUD operations, modal, and form state
-  const {
-    showModal,
-    isEditing,
-    formData,
-    formErrors,
-    isSubmitting,
-    handleChange,
-    handleOpen,
-    handleClose,
-    handleSubmit,
-    handleDelete,
-  } = useCRUD({
-    fetchAction: fetchPatients,
-    addAction: addPatient,
-    updateAction: updatePatient,
-    deleteAction: deletePatient,
-    initialFormState: {
-      name: '',
-      age: '',
-      gender: 'Male',
-      mobile: '',
-      address: '',
-      email: '',
-    },
-    transformData: (data) => ({
-      ...data,
-      age: parseInt(data.age),
-    }),
-    onSuccess: (action) => {
-      success(`Patient ${action} successfully!`);
-    },
-    onError: (err) => {
-      showError(err.message || 'Operation failed');
-    },
-  });
-
-  // Custom render actions with permissions
-  const renderActions = (item) => (
-    <>
-      <PermissionGate resource="patients" action="edit">
-        <Button
-          size="sm"
-          onClick={() => handleOpen(item)}
-          className="me-2"
-          style={{
-            backgroundColor: 'transparent',
-            border: '2px solid #0891B2',
-            color: '#0891B2'
-          }}
-        >
-          <FaEdit className="me-1" />
-          Edit
-        </Button>
-      </PermissionGate>
-      <PermissionGate resource="patients" action="delete">
-        <Button
-          size="sm"
-          onClick={() => handleDelete(item.id, 'Are you sure you want to delete this patient?')}
-          style={{
-            backgroundColor: 'transparent',
-            border: '2px solid #0aa2c0',
-            color: '#0aa2c0'
-          }}
-        >
-          <FaTrash className="me-1" />
-          Delete
-        </Button>
-      </PermissionGate>
-    </>
-  );
-
-  const hasEditOrDelete = checkPermission('patients', 'edit') || checkPermission('patients', 'delete');
-
   return (
     <Container fluid className="p-3 p-md-4">
       <PageHeader
         icon={FaUserInjured}
         title="Patients Management"
-        onAddClick={checkPermission('patients', 'create') ? () => handleOpen() : undefined}
+        onAddClick={checkPermission('patients', 'create') ? () => navigate('/patients/new') : undefined}
         addButtonText="Add New Patient"
         showAddButton={checkPermission('patients', 'create')}
       />
@@ -188,7 +71,6 @@ function Patients() {
           <EnhancedCRUDTable
             data={patients}
             columns={TABLE_COLUMNS}
-            renderActions={hasEditOrDelete ? renderActions : undefined}
             loading={loading}
             error={error}
             emptyMessage="No patients registered yet"
@@ -197,78 +79,6 @@ function Patients() {
           />
         </Col>
       </Row>
-
-      <CRUDModal
-        show={showModal}
-        title={isEditing ? 'Edit Patient' : 'Add New Patient'}
-        isEditing={isEditing}
-        fields={PATIENT_FIELDS}
-        formData={formData}
-        formErrors={formErrors}
-        onFormChange={handleChange}
-        onSubmit={handleSubmit}
-        onClose={handleClose}
-        loading={isSubmitting}
-      >
-        <Row>
-          {PATIENT_FIELDS.slice(0, 2).map((field) => (
-            <Col key={field.name} xs={12} md={field.colSize || 6}>
-              <Form.Group className="mb-3">
-                <Form.Label>
-                  {field.label}
-                  {field.required && <span className="text-danger ms-1">*</span>}
-                </Form.Label>
-                <Form.Control
-                  type={field.type}
-                  name={field.name}
-                  value={formData[field.name] || ''}
-                  onChange={handleChange}
-                  required={field.required}
-                  disabled={isSubmitting}
-                />
-              </Form.Group>
-            </Col>
-          ))}
-          <Col xs={12}>
-            <GenderIconSelector
-              value={formData.gender}
-              onChange={handleChange}
-              name="gender"
-              disabled={isSubmitting}
-            />
-          </Col>
-          {PATIENT_FIELDS.slice(2).map((field) => (
-            <Col key={field.name} xs={12} md={field.colSize || 6}>
-              <Form.Group className="mb-3">
-                <Form.Label>
-                  {field.label}
-                  {field.required && <span className="text-danger ms-1">*</span>}
-                </Form.Label>
-                {field.type === 'textarea' ? (
-                  <Form.Control
-                    as="textarea"
-                    rows={field.rows || 3}
-                    name={field.name}
-                    value={formData[field.name] || ''}
-                    onChange={handleChange}
-                    required={field.required}
-                    disabled={isSubmitting}
-                  />
-                ) : (
-                  <Form.Control
-                    type={field.type}
-                    name={field.name}
-                    value={formData[field.name] || ''}
-                    onChange={handleChange}
-                    required={field.required}
-                    disabled={isSubmitting}
-                  />
-                )}
-              </Form.Group>
-            </Col>
-          ))}
-        </Row>
-      </CRUDModal>
     </Container>
   );
 }

--- a/src/pages/TestDetail.jsx
+++ b/src/pages/TestDetail.jsx
@@ -1,0 +1,177 @@
+import { useEffect, useCallback } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { useSelector, useDispatch } from 'react-redux'
+import { Container, Row, Col, Card, Button } from 'react-bootstrap'
+import { FaFlask, FaArrowLeft } from 'react-icons/fa'
+import { selectAllTests, addTest, updateTest, deleteTest, fetchTests } from '../store/testsSlice'
+import { useForm } from '../hooks'
+import { useNotification } from '../context'
+import { EntityForm } from '../components/crud'
+import { usePermission } from '../components/auth/PermissionGate'
+
+const TEST_FIELDS = [
+  { name: 'code', label: 'Test Code', type: 'text', required: true, colSize: 6, placeholder: 'e.g., S108' },
+  { name: 'name', label: 'Test Name', type: 'text', required: true, colSize: 6 },
+  { name: 'price', label: 'Price (Rs.)', type: 'number', required: true, colSize: 6, props: { step: '0.01' } },
+  { name: 'percentage', label: 'Commission (%)', type: 'number', required: true, colSize: 6, props: { step: '1', min: '0', max: '100' }, placeholder: '20' },
+  { name: 'details', label: 'Test Details', type: 'textarea', required: false, colSize: 6, rows: 3 },
+  { name: 'rules', label: 'Test Rules/Instructions', type: 'textarea', required: false, colSize: 6, rows: 3 },
+];
+
+const INITIAL_FORM = {
+  code: '',
+  name: '',
+  price: '',
+  percentage: '20',
+  details: '',
+  rules: '',
+};
+
+function TestDetail() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const dispatch = useDispatch()
+  const tests = useSelector(selectAllTests)
+  const { loading } = useSelector(state => state.tests)
+  const { success, error: showError } = useNotification()
+  const { checkPermission } = usePermission()
+
+  const isNew = id === 'new'
+  const test = isNew ? null : tests.find(t => t.id === id)
+
+  const validate = useCallback((data) => {
+    const errors = {}
+    // Only check code uniqueness if code was changed from original
+    const codeChanged = isNew || data.code?.toLowerCase() !== test?.code?.toLowerCase()
+    if (codeChanged) {
+      const codeExists = tests.find(t =>
+        t.code?.toLowerCase() === data.code?.toLowerCase() &&
+        t.id !== id
+      )
+      if (codeExists) {
+        errors.code = `Test code "${data.code}" already exists. Please use a unique code.`
+      }
+    }
+    return errors
+  }, [tests, id, isNew, test?.code])
+
+  const handleFormSubmit = useCallback(async (formData) => {
+    const dataToSubmit = {
+      ...formData,
+      price: parseFloat(formData.price),
+      percentage: parseInt(formData.percentage) || 20,
+    }
+
+    try {
+      if (isNew) {
+        const result = await dispatch(addTest(dataToSubmit))
+        if (result.type.includes('rejected')) {
+          throw new Error(result.payload || 'Failed to add test')
+        }
+        success('Test added successfully!')
+        navigate(`/tests/${result.payload.id}`, { replace: true })
+      } else {
+        const result = await dispatch(updateTest({ id, ...dataToSubmit }))
+        if (result.type.includes('rejected')) {
+          throw new Error(result.payload || 'Failed to update test')
+        }
+        success('Test updated successfully!')
+      }
+    } catch (err) {
+      showError(err.message || 'Operation failed')
+      throw err
+    }
+  }, [isNew, id, dispatch, navigate, success, showError])
+
+  const form = useForm(INITIAL_FORM, handleFormSubmit, validate)
+
+  // Load test data into form when editing
+  useEffect(() => {
+    if (test) {
+      form.resetTo({
+        code: test.code || '',
+        name: test.name || '',
+        price: test.price?.toString() || '',
+        percentage: test.percentage?.toString() || '20',
+        details: test.details || '',
+        rules: test.rules || '',
+      })
+    }
+  }, [test?.id]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Fetch tests if store is empty
+  useEffect(() => {
+    if (tests.length === 0) {
+      dispatch(fetchTests())
+    }
+  }, [dispatch, tests.length])
+
+  const handleDelete = async () => {
+    if (!window.confirm('Are you sure you want to delete this test?')) return
+    try {
+      const result = await dispatch(deleteTest({ id, testName: test?.name }))
+      if (result.type.includes('rejected')) {
+        throw new Error(result.payload || 'Failed to delete test')
+      }
+      success('Test deleted successfully!')
+      navigate('/tests')
+    } catch (err) {
+      showError(err.message || 'Delete failed')
+    }
+  }
+
+  // Not found
+  if (!isNew && !test && tests.length > 0) {
+    return (
+      <Container fluid className="p-3 p-md-4">
+        <Card>
+          <Card.Body className="text-center py-5">
+            <h4>Test not found</h4>
+            <Button
+              onClick={() => navigate('/tests')}
+              style={{ backgroundColor: '#06B6D4', border: 'none', color: 'white' }}
+            >
+              <FaArrowLeft className="me-2" />
+              Back to Tests
+            </Button>
+          </Card.Body>
+        </Card>
+      </Container>
+    )
+  }
+
+  const canEdit = checkPermission('tests', isNew ? 'create' : 'edit')
+  const canDelete = !isNew && checkPermission('tests', 'delete')
+
+  return (
+    <Container fluid className="p-3 p-md-4">
+      <Row className="mb-4">
+        <Col>
+          <h2 style={{ fontSize: 'clamp(1.2rem, 3vw, 1.75rem)' }}>
+            <FaFlask className="me-2" style={{ color: '#0891B2' }} />
+            {isNew ? 'Add New Test' : 'Test Details'}
+          </h2>
+        </Col>
+      </Row>
+
+      <Row>
+        <Col>
+          <EntityForm
+            title={isNew ? 'New Test Information' : `Edit Test: ${test?.name || ''}`}
+            fields={TEST_FIELDS}
+            formData={form.formData}
+            formErrors={form.errors}
+            onFormChange={form.handleChange}
+            onSubmit={form.handleSubmit}
+            onCancel={() => navigate('/tests')}
+            onDelete={canDelete ? handleDelete : undefined}
+            loading={form.isSubmitting || loading}
+            isEditing={!isNew}
+          />
+        </Col>
+      </Row>
+    </Container>
+  )
+}
+
+export default TestDetail

--- a/src/pages/Tests.jsx
+++ b/src/pages/Tests.jsx
@@ -1,203 +1,111 @@
-import { useSelector } from 'react-redux'
-import { Container, Row, Col, Button } from 'react-bootstrap'
-import { FaFlask, FaEdit, FaTrash } from 'react-icons/fa'
-import { fetchTests, addTest, updateTest, deleteTest, selectAllTests } from '../store/testsSlice'
-import { useCRUD } from '../hooks'
-import { useNotification } from '../context'
+import { useEffect } from 'react'
+import { useSelector, useDispatch } from 'react-redux'
+import { useNavigate } from 'react-router-dom'
+import { Container, Row, Col } from 'react-bootstrap'
+import { FaFlask } from 'react-icons/fa'
+import { fetchTests, selectAllTests } from '../store/testsSlice'
 import { PageHeader } from '../components/ui'
-import { EnhancedCRUDTable, CRUDModal } from '../components/crud'
-import { PermissionGate, usePermission } from '../components/auth/PermissionGate'
-
-// Form field configuration
-const TEST_FIELDS = [
-  { name: 'code', label: 'Test Code', type: 'text', required: true, colSize: 6, placeholder: 'e.g., S108' },
-  { name: 'name', label: 'Test Name', type: 'text', required: true, colSize: 6 },
-  { name: 'price', label: 'Price (Rs.)', type: 'number', required: true, colSize: 6, props: { step: '0.01' } },
-  { name: 'percentage', label: 'Commission (%)', type: 'number', required: true, colSize: 6, props: { step: '1', min: '0', max: '100' }, placeholder: '20' },
-  { name: 'details', label: 'Test Details', type: 'textarea', required: false, colSize: 6, rows: 3 },
-  { name: 'rules', label: 'Test Rules/Instructions', type: 'textarea', required: false, colSize: 6, rows: 3 },
-];
-
-// Table column configuration
-const TABLE_COLUMNS = [
-  {
-    key: 'code',
-    label: 'Code',
-    render: (value) => (
-      <strong style={{
-        color: '#0891B2',
-        whiteSpace: 'nowrap'
-      }}>
-        {value}
-      </strong>
-    )
-  },
-  {
-    key: 'name',
-    label: 'Test Name',
-    render: (value) => (
-      <strong style={{
-        whiteSpace: 'pre-wrap',
-        wordWrap: 'break-word',
-        maxWidth: window.innerWidth < 768 ? '150px' : '250px',
-        display: 'inline-block'
-      }}>
-        {value}
-      </strong>
-    )
-  },
-  {
-    key: 'price',
-    label: 'Price (Rs.)',
-    render: (value) => (
-      <span style={{ whiteSpace: 'nowrap' }}>
-        Rs. {parseFloat(value).toFixed(2)}
-      </span>
-    )
-  },
-  {
-    key: 'percentage',
-    label: 'Commission',
-    align: 'center',
-    render: (value) => (
-      <span style={{ whiteSpace: 'nowrap', color: '#0891B2', fontWeight: '500' }}>
-        {value || 20}%
-      </span>
-    )
-  },
-  {
-    key: 'details',
-    label: 'Details',
-    render: (value) => (
-      <div style={{
-        whiteSpace: 'pre-wrap',
-        wordWrap: 'break-word',
-        maxWidth: window.innerWidth < 768 ? '120px' : '200px'
-      }}>
-        {value}
-      </div>
-    )
-  },
-  {
-    key: 'rules',
-    label: 'Rules',
-    render: (value) => (
-      <div style={{
-        whiteSpace: 'pre-wrap',
-        wordWrap: 'break-word',
-        maxWidth: window.innerWidth < 768 ? '120px' : '200px'
-      }}>
-        {value}
-      </div>
-    )
-  },
-];
+import { EnhancedCRUDTable } from '../components/crud'
+import { usePermission } from '../components/auth/PermissionGate'
 
 function Tests() {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
   const tests = useSelector(selectAllTests);
   const { loading, error } = useSelector(state => state.tests);
-  const { success, error: showError } = useNotification();
   const { checkPermission } = usePermission();
 
-  // Custom validation for unique code field
-  const validateForm = (data, isEdit, editingId) => {
-    const errors = {};
+  useEffect(() => {
+    dispatch(fetchTests());
+  }, [dispatch]);
 
-    // Check if code is unique
-    const codeExists = tests.find(test =>
-      test.code?.toLowerCase() === data.code?.toLowerCase() &&
-      test.id !== editingId
-    );
-
-    if (codeExists) {
-      errors.code = `Test code "${data.code}" already exists. Please use a unique code.`;
-    }
-
-    return errors;
-  };
-
-  // Custom hook handles ALL CRUD operations, modal, and form state
-  const {
-    showModal,
-    isEditing,
-    formData,
-    formErrors,
-    isSubmitting,
-    handleChange,
-    handleOpen,
-    handleClose,
-    handleSubmit,
-    handleDelete,
-  } = useCRUD({
-    fetchAction: fetchTests,
-    addAction: addTest,
-    updateAction: updateTest,
-    deleteAction: deleteTest,
-    initialFormState: {
-      code: '',
-      name: '',
-      price: '',
-      percentage: '20',
-      details: '',
-      rules: '',
-    },
-    transformData: (data) => ({
-      ...data,
-      price: parseFloat(data.price),
-      percentage: parseInt(data.percentage) || 20,
-    }),
-    customValidation: validateForm,
-    onSuccess: (action) => {
-      success(`Test ${action} successfully!`);
-    },
-    onError: (err) => {
-      showError(err.message || 'Operation failed');
-    },
-  });
-
-  // Custom render actions with permissions
-  const renderActions = (item) => (
-    <>
-      <PermissionGate resource="tests" action="edit">
-        <Button
-          size="sm"
-          onClick={() => handleOpen(item)}
-          className="me-2"
+  const TABLE_COLUMNS = [
+    {
+      key: 'code',
+      label: 'Code',
+      render: (value, item) => (
+        <strong
+          onClick={() => navigate(`/tests/${item.id}`)}
           style={{
-            backgroundColor: 'transparent',
-            border: '2px solid #0891B2',
-            color: '#0891B2'
+            color: '#0891B2',
+            whiteSpace: 'nowrap',
+            cursor: 'pointer',
+            textDecoration: 'none'
           }}
+          onMouseEnter={(e) => e.target.style.textDecoration = 'underline'}
+          onMouseLeave={(e) => e.target.style.textDecoration = 'none'}
         >
-          <FaEdit className="me-1" />
-          Edit
-        </Button>
-      </PermissionGate>
-      <PermissionGate resource="tests" action="delete">
-        <Button
-          size="sm"
-          onClick={() => handleDelete({ id: item.id, testName: item.name }, 'Are you sure you want to delete this test?')}
-          style={{
-            backgroundColor: 'transparent',
-            border: '2px solid #0aa2c0',
-            color: '#0aa2c0'
-          }}
-        >
-          <FaTrash className="me-1" />
-          Delete
-        </Button>
-      </PermissionGate>
-    </>
-  );
-
-  const hasEditOrDelete = checkPermission('tests', 'edit') || checkPermission('tests', 'delete');
+          {value}
+        </strong>
+      )
+    },
+    {
+      key: 'name',
+      label: 'Test Name',
+      render: (value) => (
+        <strong style={{
+          whiteSpace: 'pre-wrap',
+          wordWrap: 'break-word',
+          maxWidth: window.innerWidth < 768 ? '150px' : '250px',
+          display: 'inline-block'
+        }}>
+          {value}
+        </strong>
+      )
+    },
+    {
+      key: 'price',
+      label: 'Price (Rs.)',
+      render: (value) => (
+        <span style={{ whiteSpace: 'nowrap' }}>
+          Rs. {parseFloat(value).toFixed(2)}
+        </span>
+      )
+    },
+    {
+      key: 'percentage',
+      label: 'Commission',
+      align: 'center',
+      render: (value) => (
+        <span style={{ whiteSpace: 'nowrap', color: '#0891B2', fontWeight: '500' }}>
+          {value || 20}%
+        </span>
+      )
+    },
+    {
+      key: 'details',
+      label: 'Details',
+      render: (value) => (
+        <div style={{
+          whiteSpace: 'pre-wrap',
+          wordWrap: 'break-word',
+          maxWidth: window.innerWidth < 768 ? '120px' : '200px'
+        }}>
+          {value}
+        </div>
+      )
+    },
+    {
+      key: 'rules',
+      label: 'Rules',
+      render: (value) => (
+        <div style={{
+          whiteSpace: 'pre-wrap',
+          wordWrap: 'break-word',
+          maxWidth: window.innerWidth < 768 ? '120px' : '200px'
+        }}>
+          {value}
+        </div>
+      )
+    },
+  ];
 
   return (
     <Container fluid className="p-3 p-md-4">
       <PageHeader
         icon={FaFlask}
         title="Blood Tests Management"
-        onAddClick={checkPermission('tests', 'create') ? () => handleOpen() : undefined}
+        onAddClick={checkPermission('tests', 'create') ? () => navigate('/tests/new') : undefined}
         addButtonText="Add New Test"
         showAddButton={checkPermission('tests', 'create')}
       />
@@ -207,7 +115,6 @@ function Tests() {
           <EnhancedCRUDTable
             data={tests}
             columns={TABLE_COLUMNS}
-            renderActions={hasEditOrDelete ? renderActions : undefined}
             loading={loading}
             error={error}
             emptyMessage="No tests available"
@@ -216,19 +123,6 @@ function Tests() {
           />
         </Col>
       </Row>
-
-      <CRUDModal
-        show={showModal}
-        title={isEditing ? 'Edit Test' : 'Add New Test'}
-        isEditing={isEditing}
-        fields={TEST_FIELDS}
-        formData={formData}
-        formErrors={formErrors}
-        onFormChange={handleChange}
-        onSubmit={handleSubmit}
-        onClose={handleClose}
-        loading={isSubmitting}
-      />
     </Container>
   );
 }


### PR DESCRIPTION
## Summary
- Replace modal-based add/edit flows with dedicated pages for Checkups, Tests, Medicines, and Patients
- Add new `CheckupForm.jsx` page with patient selection (editable in both add/edit mode), test multi-select, and inline "Add New Patient" form
- Add `EntityForm` reusable component and `TestDetail`, `MedicineDetail` detail pages
- Simplify list pages (`Checkups.jsx`, `Tests.jsx`, `Medicines.jsx`, `Patients.jsx`) by removing modal code
- Consistent routing pattern: `/resource/new` for add, `/resource/:id/edit` for edit

## Test plan
- [ ] `/checkups` → "New Checkup" button navigates to `/checkups/new`
- [ ] `/checkups/new` → select patient, select tests, save → redirects to `/checkups/:id`
- [ ] `/checkups/:id` → "Edit Checkup" → `/checkups/:id/edit` with all fields pre-filled and editable (including patient)
- [ ] "Add New Patient" inline form works in both add and edit checkup pages
- [ ] Delete checkup from edit page works correctly
- [ ] Notes/Prescription inline editing on CheckupDetail still works
- [ ] Tests, Medicines, Patients add/edit pages work with same pattern
- [ ] `npm run build` passes with no errors