### PR TITLE
fix: resolve hooks ordering error in Checkups page

### DIFF
--- a/src/pages/Checkups.jsx
+++ b/src/pages/Checkups.jsx
@@ -28,10 +28,6 @@ function Checkups() {
     dispatch(fetchTests())
   }, [dispatch])
 
-  if (loading && checkups.length === 0) {
-    return <LoadingSpinner text="Loading checkups data..." />
-  }
-
   const handleViewDetails = (checkupId) => {
     navigate(`/checkups/${checkupId}`)
   }
@@ -51,6 +47,10 @@ function Checkups() {
       }
     })
   }, [checkups, patients, tests])
+
+  if (loading && checkups.length === 0) {
+    return <LoadingSpinner text="Loading checkups data..." />
+  }
 
   const TABLE_COLUMNS = [
     {
@@ -115,9 +115,8 @@ function Checkups() {
             <PermissionGate resource="checkups" action="create">
               <Button
                 onClick={() => navigate('/checkups/new')}
-                className="mt-2 mt-md-0"
                 disabled={patients.length === 0 || loading}
-                className="btn-theme-add"
+                className="btn-theme-add mt-2 mt-md-0"
               >
                 <FaPlus className="me-2" />New Checkup
               </Button>


### PR DESCRIPTION
## Summary
- Fixed React hooks ordering error (`Rendered fewer hooks than expected`) on `/checkups` page by moving early return after `useMemo` hook
- Fixed duplicate `className` prop on New Checkup button

## Test plan
- [ ] Navigate to `/checkups` — no console errors
- [ ] Loading spinner displays correctly while data loads
- [ ] New Checkup button styled correctly with proper disabled state