### PR TITLE
fix: add missing React import in PatientDetail

### DIFF
--- a/src/pages/PatientDetail.jsx
+++ b/src/pages/PatientDetail.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react'
+import React, { useEffect, useState, useCallback } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useSelector, useDispatch } from 'react-redux'
 import { Container, Row, Col, Card, Button, Table, Badge, Collapse, Form } from 'react-bootstrap'


### PR DESCRIPTION
## Summary
- Added missing `React` import in `PatientDetail.jsx` to fix `React is not defined` error caused by `<React.Fragment key={...}>` usage

## Test plan
- [ ] Navigate to `/patients/:id` — no console errors
- [ ] Patient checkup history table renders correctly with expandable rows