### PR TITLE
feat: convert UsersTab to page-based navigation & UI improvements

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,6 +24,7 @@ const TestDetail = lazy(() => import('./pages/TestDetail'))
 const Medicines = lazy(() => import('./pages/Medicines'))
 const MedicineDetail = lazy(() => import('./pages/MedicineDetail'))
 const UserManagement = lazy(() => import('./pages/UserManagement'))
+const UserDetail = lazy(() => import('./pages/UserDetail'))
 const AdminSetup = lazy(() => import('./pages/AdminSetup'))
 
 // Create a wrapper component to access notification context
@@ -190,6 +191,14 @@ function AppContent() {
                 element={
                   <ProtectedRoute adminOnly={true}>
                     <UserManagement />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/users/:id"
+                element={
+                  <ProtectedRoute adminOnly={true}>
+                    <UserDetail />
                   </ProtectedRoute>
                 }
               />

--- a/src/pages/UserDetail.jsx
+++ b/src/pages/UserDetail.jsx
@@ -1,0 +1,249 @@
+import { useState, useEffect, useMemo, useCallback } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { useSelector, useDispatch } from 'react-redux'
+import { Container, Row, Col, Card, Button, Spinner } from 'react-bootstrap'
+import { FaUsers, FaArrowLeft, FaKey } from 'react-icons/fa'
+import { fetchUsers, updateUser, deleteUser, selectAllUsers } from '../store/usersSlice'
+import { registerUser } from '../store/authSlice'
+import { authService } from '../services/authService'
+import { logActivity, ACTIVITY_TYPES, createActivityDescription } from '../services/activityService'
+import { useForm } from '../hooks'
+import { useNotification } from '../context'
+import { EntityForm } from '../components/crud'
+import { usePermission } from '../components/auth/PermissionGate'
+
+const USER_FIELDS = [
+  { name: 'username', label: 'Username', type: 'text', required: true, colSize: 6 },
+  { name: 'email', label: 'Email', type: 'email', required: true, colSize: 6 },
+  { name: 'mobile', label: 'Mobile', type: 'tel', required: true, colSize: 6 },
+  { name: 'role', label: 'Role', type: 'select', required: true, colSize: 6, options: [
+    { value: 'user', label: 'User' },
+    { value: 'editor', label: 'Editor' },
+    { value: 'maintainer', label: 'Maintainer' },
+    { value: 'admin', label: 'Admin' },
+    { value: 'superadmin', label: 'Superadmin' },
+  ]},
+];
+
+const INITIAL_FORM = {
+  username: '',
+  email: '',
+  mobile: '',
+  role: 'user',
+  password: '',
+};
+
+function UserDetail() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const dispatch = useDispatch()
+  const users = useSelector(selectAllUsers)
+  const { loading } = useSelector(state => state.users)
+  const { user: currentUser } = useSelector(state => state.auth)
+  const { success, error: showError } = useNotification()
+  const { checkPermission } = usePermission()
+  const [resettingPassword, setResettingPassword] = useState(false)
+
+  const isNew = id === 'new'
+  const user = isNew ? null : users.find(u => u.id === id)
+
+  // Only show password field for new users; editing uses reset email instead
+  const fields = useMemo(() => {
+    if (isNew) {
+      return [
+        ...USER_FIELDS,
+        { name: 'password', label: 'Password', type: 'password', required: true, colSize: 6 },
+      ]
+    }
+    return USER_FIELDS
+  }, [isNew])
+
+  const handleFormSubmit = useCallback(async (formData) => {
+    try {
+      if (isNew) {
+        const result = await dispatch(registerUser(formData))
+        if (result.type.includes('rejected')) {
+          throw new Error(result.payload || 'Failed to create user')
+        }
+        await dispatch(fetchUsers())
+        success('User created successfully!')
+        navigate(`/users/${result.payload.uid}`, { replace: true })
+      } else {
+        const { password, ...dataToSubmit } = formData
+        const result = await dispatch(updateUser({ id, ...dataToSubmit }))
+        if (result.type.includes('rejected')) {
+          throw new Error(result.payload || 'Failed to update user')
+        }
+        success('User updated successfully!')
+      }
+    } catch (err) {
+      showError(err.message || 'Operation failed')
+      throw err
+    }
+  }, [isNew, id, dispatch, navigate, success, showError])
+
+  const form = useForm(INITIAL_FORM, handleFormSubmit)
+
+  // Load user data into form when editing
+  useEffect(() => {
+    if (user) {
+      form.resetTo({
+        username: user.username || '',
+        email: user.email || '',
+        mobile: user.mobile || '',
+        role: user.role || 'user',
+        password: '',
+      })
+    }
+  }, [user?.id]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Fetch users if store is empty
+  useEffect(() => {
+    if (users.length === 0) {
+      dispatch(fetchUsers())
+    }
+  }, [dispatch, users.length])
+
+  const handleDelete = async () => {
+    if (!window.confirm('Are you sure you want to delete this user?')) return
+    try {
+      const result = await dispatch(deleteUser(id))
+      if (result.type.includes('rejected')) {
+        throw new Error(result.payload || 'Failed to delete user')
+      }
+      success('User deleted successfully!')
+      navigate('/users')
+    } catch (err) {
+      showError(err.message || 'Delete failed')
+    }
+  }
+
+  const handleResetPassword = async () => {
+    const email = user?.email
+    if (!email) {
+      showError('User email not found')
+      return
+    }
+    if (!window.confirm(`Send password reset email to ${email}?`)) return
+
+    setResettingPassword(true)
+    try {
+      const result = await authService.resetPassword(email)
+      if (result.success) {
+        // Log password reset activity
+        if (currentUser) {
+          await logActivity({
+            userId: currentUser.uid,
+            username: currentUser.username || currentUser.email,
+            userRole: currentUser.role,
+            activityType: ACTIVITY_TYPES.USER_PASSWORD_RESET,
+            description: createActivityDescription(ACTIVITY_TYPES.USER_PASSWORD_RESET, {
+              username: user.username
+            }),
+            metadata: {
+              targetUserId: id,
+              targetUsername: user.username,
+              targetEmail: email,
+            }
+          })
+        }
+        success(`Password reset email sent to ${email}`)
+      } else {
+        throw new Error(result.error || 'Failed to send reset email')
+      }
+    } catch (err) {
+      showError(err.message || 'Failed to send reset email')
+    } finally {
+      setResettingPassword(false)
+    }
+  }
+
+  // Not found
+  if (!isNew && !user && users.length > 0) {
+    return (
+      <Container fluid className="p-3 p-md-4">
+        <Card>
+          <Card.Body className="text-center py-5">
+            <h4>User not found</h4>
+            <Button
+              onClick={() => navigate('/users')}
+              className="btn-theme"
+            >
+              <FaArrowLeft className="me-2" />
+              Back to Users
+            </Button>
+          </Card.Body>
+        </Card>
+      </Container>
+    )
+  }
+
+  const canEdit = checkPermission('users', isNew ? 'create' : 'edit')
+  const canDelete = !isNew && checkPermission('users', 'delete')
+
+  return (
+    <Container fluid className="p-3 p-md-4">
+      <Row className="mb-4">
+        <Col>
+          <h2 className="fs-responsive-lg">
+            <FaUsers className="me-2 text-theme" />
+            {isNew ? 'Add New User' : 'User Details'}
+          </h2>
+        </Col>
+      </Row>
+
+      <Row>
+        <Col>
+          <EntityForm
+            title={isNew ? 'New User Information' : `Edit User: ${user?.username || ''}`}
+            fields={fields}
+            formData={form.formData}
+            formErrors={form.errors}
+            onFormChange={form.handleChange}
+            onSubmit={form.handleSubmit}
+            onCancel={() => navigate('/users')}
+            onDelete={canDelete ? handleDelete : undefined}
+            loading={form.isSubmitting || loading}
+            isEditing={!isNew}
+          />
+        </Col>
+      </Row>
+
+      {!isNew && user && (
+        <Row className="mt-3">
+          <Col>
+            <Card className="shadow-sm">
+              <Card.Header className="card-header-theme">
+                <h5 className="mb-0 fs-responsive-md">Password Management</h5>
+              </Card.Header>
+              <Card.Body>
+                <p className="text-muted mb-3">
+                  Send a password reset link to the user's email address ({user.email}).
+                </p>
+                <Button
+                  onClick={handleResetPassword}
+                  disabled={resettingPassword}
+                  variant="outline-warning"
+                >
+                  {resettingPassword ? (
+                    <>
+                      <Spinner size="sm" className="me-2" />
+                      Sending...
+                    </>
+                  ) : (
+                    <>
+                      <FaKey className="me-2" />
+                      Send Password Reset Email
+                    </>
+                  )}
+                </Button>
+              </Card.Body>
+            </Card>
+          </Col>
+        </Row>
+      )}
+    </Container>
+  )
+}
+
+export default UserDetail

--- a/src/pages/tabs/UsersTab.jsx
+++ b/src/pages/tabs/UsersTab.jsx
@@ -1,188 +1,81 @@
+import { useEffect } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
-import { Row, Col, Badge, Alert } from 'react-bootstrap'
-import { fetchUsers, updateUser, deleteUser, selectAllUsers } from '../../store/usersSlice'
-import { registerUser } from '../../store/authSlice'
-import { useCRUD } from '../../hooks'
-import { useNotification } from '../../context'
-import { CRUDTable, CRUDModal } from '../../components/crud'
-import { useState } from 'react'
-import { Button } from 'react-bootstrap'
+import { useNavigate } from 'react-router-dom'
+import { Row, Col, Badge, Button } from 'react-bootstrap'
 import { FaPlus } from 'react-icons/fa'
-
-// Form field configuration
-const USER_FIELDS = [
-  { name: 'username', label: 'Username', type: 'text', required: true, colSize: 6 },
-  { name: 'email', label: 'Email', type: 'email', required: true, colSize: 6 },
-  { name: 'mobile', label: 'Mobile', type: 'tel', required: true, colSize: 6 },
-  { name: 'role', label: 'Role', type: 'select', required: true, colSize: 6, options: [
-    { value: 'user', label: 'User' },
-    { value: 'admin', label: 'Admin' }
-  ]},
-];
-
-// Table column configuration
-const TABLE_COLUMNS = [
-  { key: 'username', label: 'Username', render: (value) => <strong>{value}</strong> },
-  { key: 'email', label: 'Email' },
-  { key: 'mobile', label: 'Mobile' },
-  {
-    key: 'role',
-    label: 'Role',
-    render: (value) => (
-      <Badge className={value === 'admin' ? 'badge-theme' : 'badge-theme-light'}>
-        {value}
-      </Badge>
-    )
-  },
-];
+import { fetchUsers, selectAllUsers } from '../../store/usersSlice'
+import { EnhancedCRUDTable } from '../../components/crud'
+import { usePermission } from '../../components/auth/PermissionGate'
 
 function UsersTab() {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
   const users = useSelector(selectAllUsers);
-  const { loading } = useSelector(state => state.users);
-  const { success, error: showError } = useNotification();
-  const [formError, setFormError] = useState('');
+  const { loading, error } = useSelector(state => state.users);
+  const { checkPermission } = usePermission();
 
-  // Custom submit handler for Users (special case: uses registerUser for add)
-  const handleUserSubmit = async (formData, editingItem) => {
-    setFormError('');
+  useEffect(() => {
+    dispatch(fetchUsers());
+  }, [dispatch]);
 
-    if (editingItem) {
-      // Update existing user
-      const result = await dispatch(updateUser({ id: editingItem.id, ...formData }));
-      if (result.type.includes('fulfilled')) {
-        success('User updated successfully!');
-        return true;
-      } else {
-        const errorMsg = result.payload || 'Failed to update user';
-        setFormError(errorMsg);
-        showError(errorMsg);
-        throw new Error(errorMsg);
-      }
-    } else {
-      // Create new user with Firebase Auth
-      const result = await dispatch(registerUser(formData));
-      if (result.type.includes('fulfilled')) {
-        dispatch(fetchUsers()); // Refresh user list
-        success('User created successfully!');
-        return true;
-      } else {
-        const errorMsg = result.payload || 'Failed to create user';
-        setFormError(errorMsg);
-        showError(errorMsg);
-        throw new Error(errorMsg);
-      }
-    }
-  };
-
-  const {
-    showModal,
-    isEditing,
-    formData,
-    formErrors,
-    isSubmitting,
-    handleChange,
-    handleOpen,
-    handleClose,
-    handleDelete,
-    editingItem,
-  } = useCRUD({
-    fetchAction: fetchUsers,
-    addAction: null, // Handled manually
-    updateAction: null, // Handled manually
-    deleteAction: deleteUser,
-    initialFormState: {
-      username: '',
-      email: '',
-      password: '',
-      mobile: '',
-      role: 'user',
+  const TABLE_COLUMNS = [
+    {
+      key: 'username',
+      label: 'Username',
+      render: (value, item) => (
+        <strong
+          onClick={() => navigate(`/users/${item.id}`)}
+          className="clickable-link text-theme"
+          style={{ whiteSpace: 'nowrap' }}
+          onMouseEnter={(e) => e.target.style.textDecoration = 'underline'}
+          onMouseLeave={(e) => e.target.style.textDecoration = 'none'}
+        >
+          {value}
+        </strong>
+      )
     },
-    onSuccess: (action) => {
-      if (action === 'deleted') {
-        success('User deleted successfully!');
-      }
+    { key: 'email', label: 'Email' },
+    { key: 'mobile', label: 'Mobile' },
+    {
+      key: 'role',
+      label: 'Role',
+      render: (value) => (
+        <Badge className={value === 'admin' ? 'badge-theme' : 'badge-theme-light'}>
+          {value}
+        </Badge>
+      )
     },
-    onError: (err) => {
-      showError(err.message || 'Operation failed');
-    },
-  });
-
-  // Custom submit handler that uses our special user logic
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    try {
-      await handleUserSubmit(formData, editingItem);
-      handleClose();
-      setFormError('');
-    } catch (error) {
-      // Error already handled in handleUserSubmit
-    }
-  };
+  ];
 
   return (
     <>
       <Row className="mb-3">
         <Col className="d-flex justify-content-end">
-          <Button
-            onClick={() => handleOpen()}
-            className="btn-theme"
-          >
-            <FaPlus className="me-2" />
-            Add New User
-          </Button>
+          {checkPermission('users', 'create') && (
+            <Button
+              onClick={() => navigate('/users/new')}
+              className="btn-theme-add"
+            >
+              <FaPlus className="me-2" />
+              Add New User
+            </Button>
+          )}
         </Col>
       </Row>
 
       <Row>
         <Col>
-          <CRUDTable
+          <EnhancedCRUDTable
             data={users}
             columns={TABLE_COLUMNS}
-            onEdit={handleOpen}
-            onDelete={(id) => handleDelete(id, 'Are you sure you want to delete this user?')}
             loading={loading}
+            error={error}
             emptyMessage="No users found. Add your first user to get started."
+            itemsPerPage={10}
+            searchFields={['username', 'email', 'mobile', 'role']}
           />
         </Col>
       </Row>
-
-      <CRUDModal
-        show={showModal}
-        title={isEditing ? 'Edit User' : 'Add New User'}
-        isEditing={isEditing}
-        fields={USER_FIELDS}
-        formData={formData}
-        formErrors={formErrors}
-        onFormChange={handleChange}
-        onSubmit={handleSubmit}
-        onClose={() => {
-          handleClose();
-          setFormError('');
-        }}
-        loading={isSubmitting}
-      >
-        {formError && <Alert variant="danger" className="mb-3">{formError}</Alert>}
-
-        {/* Password field needs custom handling */}
-        <div className="mb-3">
-          <label className="form-label">
-            Password {!isEditing && <span className="text-danger">*</span>}
-          </label>
-          <input
-            type="password"
-            className="form-control"
-            name="password"
-            value={formData.password || ''}
-            onChange={handleChange}
-            required={!isEditing}
-            placeholder={isEditing ? 'Leave blank to keep current password' : ''}
-          />
-          {isEditing && (
-            <small className="text-muted">Leave blank to keep current password</small>
-          )}
-        </div>
-      </CRUDModal>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Convert UsersTab from modal CRUD to page-based add/edit pattern (matching Tests, Medicines, Patients)
- Add `UserDetail.jsx` page with create/edit/delete form and password reset via Firebase
- Add all 5 roles to dropdown (user, editor, maintainer, admin, superadmin)
- Replace CRUDTable with EnhancedCRUDTable for search and pagination
- Log password reset activity to user activity tracking
- Fix React import and hooks ordering issues in PatientDetail
- Replace inline styles with CSS utility classes and theme.css

## Test plan
- [ ] Navigate to `/users` — table shows clickable usernames, no action column
- [ ] Click username — navigates to `/users/:id` with pre-filled form
- [ ] Click "Add New User" — navigates to `/users/new` with empty form + required password
- [ ] Edit user — password field hidden, "Password Management" card with reset button
- [ ] Delete user — confirmation dialog, redirects to `/users`
- [ ] Send password reset email — logs activity in user activities
- [ ] Role dropdown shows all 5 roles
- [ ] Build passes with no errors