### PR TITLE
feat: login page controls, unified PDFs, role-based columns, auto-release CI

### DIFF
--- a/src/constants/defaultSettings.js
+++ b/src/constants/defaultSettings.js
@@ -131,6 +131,11 @@ export const DEFAULT_SETTINGS = {
     },
   },
   pages: {
+    login: {
+      label: 'Login', path: '/login', sidebar: false,
+      showResetPassword: ['superadmin', 'maintainer', 'editor', 'user'],
+      showSignUp: ['superadmin', 'maintainer', 'editor', 'user'],
+    },
     home: {
       label: 'Home', icon: 'FaHome', path: '/', order: 0,
       sidebar: false,

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -7,12 +7,19 @@ import { loginUser, setUser } from '../store/authSlice'
 import { authService } from '../services/authService'
 import { logActivity, ACTIVITY_TYPES, createActivityDescription } from '../services/activityService'
 import { useForm } from '../hooks'
+import { useSettings } from '../hooks/useSettings'
 import '../styles/Login.css'
 
 function Login() {
   const dispatch = useDispatch()
   const navigate = useNavigate()
   const { loading, error } = useSelector(state => state.auth)
+  const { settings } = useSettings()
+  const resetPasswordRoles = settings?.pages?.login?.showResetPassword
+  const signUpRoles = settings?.pages?.login?.showSignUp
+  const showResetPassword = Array.isArray(resetPasswordRoles) ? resetPasswordRoles.length > 0 : resetPasswordRoles !== false
+  const showSignUp = Array.isArray(signUpRoles) ? signUpRoles.length > 0 : signUpRoles !== false
+
   const [view, setView] = useState('login') // 'login' | 'forgot' | 'signup'
   const [message, setMessage] = useState('')
 
@@ -159,17 +166,19 @@ function Login() {
                       />
                     </Form.Group>
 
-                    <div className="text-end mb-3">
-                      <Button
-                        variant="link"
-                        className="p-0 text-decoration-none"
-                        style={{ color: '#0891B2', fontSize: '0.85rem' }}
-                        onClick={() => switchView('forgot')}
-                        type="button"
-                      >
-                        Forgot Password?
-                      </Button>
-                    </div>
+                    {showResetPassword && (
+                      <div className="text-end mb-3">
+                        <Button
+                          variant="link"
+                          className="p-0 text-decoration-none"
+                          style={{ color: '#0891B2', fontSize: '0.85rem' }}
+                          onClick={() => switchView('forgot')}
+                          type="button"
+                        >
+                          Forgot Password?
+                        </Button>
+                      </div>
+                    )}
 
                     <Button
                       type="submit"
@@ -186,20 +195,22 @@ function Login() {
                       )}
                     </Button>
 
-                    <div className="text-center mt-3">
-                      <span style={{ fontSize: '0.9rem', color: '#6b7280' }}>
-                        Don't have an account?{' '}
-                        <Button
-                          variant="link"
-                          className="p-0 text-decoration-none fw-semibold"
-                          style={{ color: '#0891B2', fontSize: '0.9rem' }}
-                          onClick={() => switchView('signup')}
-                          type="button"
-                        >
-                          Sign Up
-                        </Button>
-                      </span>
-                    </div>
+                    {showSignUp && (
+                      <div className="text-center mt-3">
+                        <span style={{ fontSize: '0.9rem', color: '#6b7280' }}>
+                          Don't have an account?{' '}
+                          <Button
+                            variant="link"
+                            className="p-0 text-decoration-none fw-semibold"
+                            style={{ color: '#0891B2', fontSize: '0.9rem' }}
+                            onClick={() => switchView('signup')}
+                            type="button"
+                          >
+                            Sign Up
+                          </Button>
+                        </span>
+                      </div>
+                    )}
                   </Form>
                 )}
 

--- a/src/pages/tabs/PagesSettingsTab.jsx
+++ b/src/pages/tabs/PagesSettingsTab.jsx
@@ -192,6 +192,57 @@ function PagesSettingsTab() {
         </Card.Body>
       </Card>
 
+      {/* Login Page Controls */}
+      <Card className="shadow-sm mb-4">
+        <Card.Header className="card-header-theme">
+          <h5 className="mb-0 fs-responsive-md">Login Page Controls</h5>
+        </Card.Header>
+        <Card.Body className="p-0">
+          <div className="table-responsive">
+            <Table hover size="sm" className="mb-0 table-mobile-responsive align-middle">
+              <thead className="bg-theme-slate">
+                <tr>
+                  <th style={{ width: '25%' }}>Feature</th>
+                  {ALL_ROLES.map(role => (
+                    <th key={role} style={{ textAlign: 'center', textTransform: 'capitalize' }}>
+                      {role}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {[
+                  { key: 'showResetPassword', label: 'Reset Password' },
+                  { key: 'showSignUp', label: 'Sign Up' },
+                ].map(({ key, label }) => {
+                  const currentRoles = Array.isArray(pages?.login?.[key]) ? pages.login[key] : ALL_ROLES
+                  return (
+                    <tr key={key}>
+                      <td data-label="Feature"><strong>{label}</strong></td>
+                      {ALL_ROLES.map(role => (
+                        <td key={role} data-label={role} style={{ textAlign: 'center' }}>
+                          <Form.Check
+                            type="switch"
+                            checked={currentRoles.includes(role)}
+                            onChange={(e) => {
+                              const newRoles = e.target.checked
+                                ? [...currentRoles, role]
+                                : currentRoles.filter(r => r !== role)
+                              handlePageFieldChange('login', key, newRoles)
+                            }}
+                            className="d-inline-block"
+                          />
+                        </td>
+                      ))}
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </Table>
+          </div>
+        </Card.Body>
+      </Card>
+
       {pagesWithTabs.length > 0 && (
         <>
           <h5 className="mb-3 mt-4 fs-responsive-md">Tab Access by Role</h5>


### PR DESCRIPTION
## Summary
- **Login page controls**: Role-based toggles for Reset Password and Sign Up link visibility in Settings > Page Access
- **Role-based column visibility**: Per-column `roles` config controls which user roles see each table column
- **Searchable toggle**: Per-column `searchable` flag to include/exclude columns from table search
- **Unified PDF templates**: Invoice and prescription share same branded header/footer
- **Dynamic PDF page sizing**: Renders at actual selected size (A5 default)
- **Prescription 70/30 layout**: Medicines left, patient vitals (H/W) right
- **Invoice PAID stamp** / **Prescription Date + Signature lines**
- **Auto-release CI**: Version bump + GitHub Release on every merge to main
- **README and CLAUDE.md updated**

## Test plan
- [x] Settings > Page Access: toggle Reset Password / Sign Up per role
- [x] Login page: links appear/disappear based on settings
- [x] Column detail: role checkboxes and searchable switch work
- [x] Invoice PDF: PAID stamp, correct page size
- [x] Prescription PDF: branded header, 70/30 layout, Date/Signature
- [x] `npm run build` passes