### PR TITLE
feat: complete activity logging and fix scatter plot date range

### DIFF
--- a/src/pages/CheckupDetail.jsx
+++ b/src/pages/CheckupDetail.jsx
@@ -92,6 +92,20 @@ function CheckupDetail() {
     }
   }, [id, checkups, patients])
 
+  // Log checkup view activity
+  useEffect(() => {
+    if (checkup && patient && user) {
+      logActivity({
+        userId: user.uid,
+        username: user.username || user.email,
+        userRole: user.role,
+        activityType: ACTIVITY_TYPES.CHECKUP_VIEW,
+        description: createActivityDescription(ACTIVITY_TYPES.CHECKUP_VIEW, { billNo: checkup.billNo, checkupId: checkup.id }),
+        metadata: { checkupId: id, billNo: checkup.billNo, patientName: patient.name }
+      })
+    }
+  }, [checkup?.id]) // eslint-disable-line react-hooks/exhaustive-deps
+
   const handleEdit = () => {
     setIsEditing(true)
   }

--- a/src/pages/MedicineDetail.jsx
+++ b/src/pages/MedicineDetail.jsx
@@ -8,6 +8,7 @@ import { useForm, useSettings } from '../hooks'
 import { useNotification } from '../context'
 import { EntityForm } from '../components/crud'
 import { usePermission } from '../components/auth/PermissionGate'
+import { logActivity, ACTIVITY_TYPES, createActivityDescription } from '../services/activityService'
 import FormField from '../components/ui/FormField'
 import RichTextEditor from '../components/ui/RichTextEditor'
 
@@ -116,6 +117,7 @@ function MedicineDetail() {
   const dispatch = useDispatch()
   const medicines = useSelector(selectAllMedicines)
   const { loading } = useSelector(state => state.medicines)
+  const user = useSelector(state => state.auth.user)
   const { success, error: showError } = useNotification()
   const { checkPermission } = usePermission()
   const { isFieldVisible, isFieldRequired, getFieldLabel, getEntityFields, getInitialFormData } = useSettings()
@@ -209,6 +211,20 @@ function MedicineDetail() {
       dispatch(fetchMedicines())
     }
   }, [dispatch, medicines.length])
+
+  // Log medicine view activity
+  useEffect(() => {
+    if (!isNew && medicine && user) {
+      logActivity({
+        userId: user.uid,
+        username: user.username || user.email,
+        userRole: user.role,
+        activityType: ACTIVITY_TYPES.MEDICINE_VIEW,
+        description: createActivityDescription(ACTIVITY_TYPES.MEDICINE_VIEW, { medicineName: medicine.name }),
+        metadata: { medicineId: id, medicineName: medicine.name }
+      })
+    }
+  }, [medicine?.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleDelete = async () => {
     if (!window.confirm('Are you sure you want to delete this medicine?')) return

--- a/src/pages/PatientDetail.jsx
+++ b/src/pages/PatientDetail.jsx
@@ -11,6 +11,7 @@ import { useForm, useSettings } from '../hooks'
 import { useNotification } from '../context'
 import { EntityForm } from '../components/crud'
 import { PermissionGate, usePermission } from '../components/auth/PermissionGate'
+import { logActivity, ACTIVITY_TYPES, createActivityDescription } from '../services/activityService'
 
 // Custom Gender Icon Selector Component
 const GenderIconSelector = ({ value, onChange, name, disabled, label = 'Gender', required = true }) => {
@@ -56,6 +57,7 @@ function PatientDetail() {
   const checkups = useSelector(selectAllCheckups)
   const tests = useSelector(selectAllTests)
   const { loading } = useSelector(state => state.patients)
+  const user = useSelector(state => state.auth.user)
   const { success, error: showError } = useNotification()
   const { checkPermission } = usePermission()
   const { getEntityFields, getInitialFormData, isFieldVisible, isFieldRequired, getFieldLabel } = useSettings()
@@ -123,6 +125,20 @@ function PatientDetail() {
       dispatch(fetchPatients())
     }
   }, [dispatch, patients.length])
+
+  // Log patient view activity
+  useEffect(() => {
+    if (!isNew && patient && user) {
+      logActivity({
+        userId: user.uid,
+        username: user.username || user.email,
+        userRole: user.role,
+        activityType: ACTIVITY_TYPES.PATIENT_VIEW,
+        description: createActivityDescription(ACTIVITY_TYPES.PATIENT_VIEW, { patientName: patient.name }),
+        metadata: { patientId: id, patientName: patient.name }
+      })
+    }
+  }, [patient?.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Build checkup history data
   useEffect(() => {

--- a/src/pages/TestDetail.jsx
+++ b/src/pages/TestDetail.jsx
@@ -8,6 +8,7 @@ import { useForm, useSettings } from '../hooks'
 import { useNotification } from '../context'
 import { EntityForm } from '../components/crud'
 import { usePermission } from '../components/auth/PermissionGate'
+import { logActivity, ACTIVITY_TYPES, createActivityDescription } from '../services/activityService'
 
 function TestDetail() {
   const { id } = useParams()
@@ -15,6 +16,7 @@ function TestDetail() {
   const dispatch = useDispatch()
   const tests = useSelector(selectAllTests)
   const { loading } = useSelector(state => state.tests)
+  const user = useSelector(state => state.auth.user)
   const { success, error: showError } = useNotification()
   const { checkPermission } = usePermission()
   const { getEntityFields, getInitialFormData } = useSettings()
@@ -95,6 +97,20 @@ function TestDetail() {
       dispatch(fetchTests())
     }
   }, [dispatch, tests.length])
+
+  // Log test view activity
+  useEffect(() => {
+    if (!isNew && test && user) {
+      logActivity({
+        userId: user.uid,
+        username: user.username || user.email,
+        userRole: user.role,
+        activityType: ACTIVITY_TYPES.TEST_VIEW,
+        description: createActivityDescription(ACTIVITY_TYPES.TEST_VIEW, { testName: test.name }),
+        metadata: { testId: id, testName: test.name }
+      })
+    }
+  }, [test?.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleDelete = async () => {
     if (!window.confirm('Are you sure you want to delete this test?')) return

--- a/src/pages/tabs/UserActivityTab.jsx
+++ b/src/pages/tabs/UserActivityTab.jsx
@@ -23,6 +23,7 @@ function UserActivityTab() {
   const [loading, setLoading] = useState(true)
   const [timeRange, setTimeRange] = useState('all') // Default: All history
   const [stats, setStats] = useState(null)
+  const [allActivities, setAllActivities] = useState([])
   const [recentActivities, setRecentActivities] = useState([])
   const [currentPage, setCurrentPage] = useState(1)
   const [totalActivities, setTotalActivities] = useState(0)
@@ -104,14 +105,15 @@ function UserActivityTab() {
         setStats(filteredStats)
       }
 
-      // Get all activities for pagination
+      // Get all activities for charts and pagination
       const activitiesResult = await getUserActivities({ days: timeRange })
       if (activitiesResult.success) {
         // Filter activities based on role
         const filteredActivities = filterActivitiesByRole(activitiesResult.data)
+        setAllActivities(filteredActivities)
         setTotalActivities(filteredActivities.length)
 
-        // Calculate pagination
+        // Calculate pagination for activity logs table
         const startIndex = (currentPage - 1) * activitiesPerPage
         const endIndex = startIndex + activitiesPerPage
         setRecentActivities(filteredActivities.slice(startIndex, endIndex))
@@ -131,46 +133,80 @@ function UserActivityTab() {
     window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' })
   }
 
-  // Prepare scatter plot data - individual activities as separate points with 30-min precision
-  const prepareScatterData = () => {
-    if (!recentActivities || recentActivities.length === 0) {
-      return []
+  // Build the full date range for the X-axis based on time range selection
+  const getDateRange = () => {
+    if (!allActivities || allActivities.length === 0) return { dates: [], dateToNum: {}, numToDate: {} }
+
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+    let startDate
+
+    if (timeRange === 'all') {
+      // Find earliest activity date
+      const earliest = allActivities.reduce((min, a) => {
+        const d = a.timestamp instanceof Date ? a.timestamp : new Date(a.timestamp)
+        return d < min ? d : min
+      }, new Date())
+      startDate = new Date(earliest)
+      startDate.setHours(0, 0, 0, 0)
+    } else {
+      startDate = new Date(today)
+      startDate.setDate(today.getDate() - (timeRange - 1))
     }
 
-    // Create scatter plot data grouped by user
-    const userScatterData = {}
+    const dates = []
+    const dateToNum = {}
+    const numToDate = {}
+    const current = new Date(startDate)
+    let i = 0
+    while (current <= today) {
+      const key = current.toISOString().split('T')[0]
+      const label = `${current.getMonth() + 1}/${current.getDate()}`
+      dates.push(key)
+      dateToNum[key] = i
+      numToDate[i] = label
+      current.setDate(current.getDate() + 1)
+      i++
+    }
 
+    return { dates, dateToNum, numToDate }
+  }
+
+  const dateRange = getDateRange()
+
+  // Prepare scatter plot data - uses ALL activities for the time range
+  const prepareScatterData = () => {
+    if (!allActivities || allActivities.length === 0) return []
+
+    const userScatterData = {}
     stats?.userStats?.forEach(userStat => {
       userScatterData[userStat.username] = []
     })
 
-    recentActivities.forEach(activity => {
+    allActivities.forEach(activity => {
       if (!activity.timestamp) return
 
       const date = activity.timestamp instanceof Date ? activity.timestamp : new Date(activity.timestamp)
       const dateKey = date.toISOString().split('T')[0]
       const hour = date.getHours()
       const minute = date.getMinutes()
-
-      // Convert to decimal time (e.g., 14:30 = 14.5)
       const timeValue = hour + (minute / 60)
 
-      const d = new Date(dateKey)
-      const displayDate = `${d.getMonth() + 1}/${d.getDate()}`
-
-      // Find the user's data array
       const username = activity.username || 'Unknown'
       if (!userScatterData[username]) {
         userScatterData[username] = []
       }
 
-      // Add each activity as individual point
+      const dayNum = dateRange.dateToNum[dateKey]
+      if (dayNum === undefined) return
+
       userScatterData[username].push({
-        date: displayDate,
+        day: dayNum,
+        date: dateRange.numToDate[dayNum],
         fullDate: dateKey,
         time: timeValue,
-        hour: hour,
-        minute: minute,
+        hour,
+        minute,
         activityType: activity.activityType,
         description: activity.description
       })
@@ -380,13 +416,15 @@ function UserActivityTab() {
                     <ScatterChart margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
                       <CartesianGrid strokeDasharray="3 3" />
                       <XAxis
-                        type="category"
-                        dataKey="date"
+                        type="number"
+                        dataKey="day"
                         name="Date"
+                        domain={[0, dateRange.dates.length - 1]}
+                        ticks={Object.keys(dateRange.numToDate).map(Number)}
+                        tickFormatter={(value) => dateRange.numToDate[value] || ''}
                         angle={-45}
                         textAnchor="end"
                         height={80}
-                        allowDuplicatedCategory={false}
                       />
                       <YAxis
                         type="number"

--- a/src/store/userChangeRequestsSlice.js
+++ b/src/store/userChangeRequestsSlice.js
@@ -2,6 +2,7 @@ import { createSlice, createAsyncThunk, createEntityAdapter } from '@reduxjs/too
 import { collection, addDoc, getDocs, updateDoc, doc, deleteDoc, query, where, serverTimestamp } from 'firebase/firestore'
 import { db } from '../config/firebase'
 import { notifyRoleRequestSubmitted, notifyRoleRequestApproved, notifyRoleRequestRejected } from '../services/notificationService'
+import { logActivity, ACTIVITY_TYPES, createActivityDescription } from '../services/activityService'
 
 const userChangeRequestsAdapter = createEntityAdapter()
 
@@ -60,6 +61,16 @@ export const createUserChangeRequest = createAsyncThunk(
         await notifyRoleRequestSubmitted(newRequest, superadminId)
       }
 
+      // Log activity
+      await logActivity({
+        userId: requestData.userId,
+        username: requestData.username || requestData.email,
+        userRole: requestData.currentRole,
+        activityType: ACTIVITY_TYPES.USER_REQUEST_CREATE,
+        description: createActivityDescription(ACTIVITY_TYPES.USER_REQUEST_CREATE, { username: requestData.username }),
+        metadata: { requestId: docRef.id, requestedRole: requestData.role }
+      })
+
       return newRequest
     } catch (error) {
       return rejectWithValue(error.message)
@@ -70,7 +81,7 @@ export const createUserChangeRequest = createAsyncThunk(
 // Approve a change request (for superadmin)
 export const approveUserChangeRequest = createAsyncThunk(
   'userChangeRequests/approve',
-  async ({ requestId, approvedBy }, { rejectWithValue }) => {
+  async ({ requestId, approvedBy }, { rejectWithValue, getState }) => {
     try {
       const requestRef = doc(db, 'userChangeRequests', requestId)
       await updateDoc(requestRef, {
@@ -78,6 +89,20 @@ export const approveUserChangeRequest = createAsyncThunk(
         approvedBy,
         approvedAt: serverTimestamp(),
       })
+
+      // Log activity
+      const { auth } = getState()
+      if (auth.user) {
+        await logActivity({
+          userId: auth.user.uid,
+          username: auth.user.username || auth.user.email,
+          userRole: auth.user.role,
+          activityType: ACTIVITY_TYPES.USER_REQUEST_APPROVE,
+          description: createActivityDescription(ACTIVITY_TYPES.USER_REQUEST_APPROVE, { username: auth.user.username }),
+          metadata: { requestId }
+        })
+      }
+
       return { id: requestId, status: 'approved', approvedBy }
     } catch (error) {
       return rejectWithValue(error.message)
@@ -88,7 +113,7 @@ export const approveUserChangeRequest = createAsyncThunk(
 // Reject a change request (for superadmin)
 export const rejectUserChangeRequest = createAsyncThunk(
   'userChangeRequests/reject',
-  async ({ requestId, rejectedBy, reason }, { rejectWithValue }) => {
+  async ({ requestId, rejectedBy, reason }, { rejectWithValue, getState }) => {
     try {
       const requestRef = doc(db, 'userChangeRequests', requestId)
       await updateDoc(requestRef, {
@@ -97,6 +122,20 @@ export const rejectUserChangeRequest = createAsyncThunk(
         rejectedAt: serverTimestamp(),
         rejectionReason: reason,
       })
+
+      // Log activity
+      const { auth } = getState()
+      if (auth.user) {
+        await logActivity({
+          userId: auth.user.uid,
+          username: auth.user.username || auth.user.email,
+          userRole: auth.user.role,
+          activityType: ACTIVITY_TYPES.USER_REQUEST_REJECT,
+          description: createActivityDescription(ACTIVITY_TYPES.USER_REQUEST_REJECT, { username: auth.user.username }),
+          metadata: { requestId, rejectionReason: reason }
+        })
+      }
+
       return { id: requestId, status: 'rejected', rejectedBy, rejectionReason: reason }
     } catch (error) {
       return rejectWithValue(error.message)


### PR DESCRIPTION
## Summary
- Add missing activity logging for all 7 undefined ACTIVITY_TYPES: PATIENT_VIEW, CHECKUP_VIEW, TEST_VIEW, MEDICINE_VIEW, USER_REQUEST_CREATE, USER_REQUEST_APPROVE, USER_REQUEST_REJECT
- Fix scatter plot to use all activities for the selected time range instead of only the paginated page (20 items)
- Fix scatter X-axis to show every day in the selected range (7d, 30d, 90d, all) including days with no activity

## Test plan
- [ ] Open a patient/test/medicine/checkup detail page and verify activity is logged in Activity tab
- [ ] Submit/approve/reject a role change request and verify it appears in Activity tab
- [ ] Select "Past 7 Days" — scatter plot X-axis shows all 7 days
- [ ] Select "All History" — scatter plot shows all days from first activity to today
- [ ] Verify all scatter dots match the activity logs table entries