### PR TITLE
feat: add rich text doctor details to prescription signature area

### DIFF
--- a/src/constants/defaultSettings.js
+++ b/src/constants/defaultSettings.js
@@ -310,6 +310,7 @@ export const DEFAULT_SETTINGS = {
       thankYouPrescription: '',
     },
     eSign: '',
+    doctorDetails: '',
     defaultValidDays: 30,
     defaultDoctorFees: 0,
     appointmentNotify: {

--- a/src/pages/CheckupDetail.jsx
+++ b/src/pages/CheckupDetail.jsx
@@ -481,6 +481,9 @@ function CheckupDetail() {
         .bill-content.pdf-clone .sig-line { width: 100px !important; }
         .bill-content.pdf-clone .date-signature-row p { font-size: ${Math.round(rxBaseFontPx * 0.85)}px !important; }
         .bill-content.pdf-clone .esign-img { height: ${Math.round(rxBaseFontPx * 3.5)}px !important; }
+        .bill-content.pdf-clone .doctor-details-inline { font-size: ${Math.round(rxBaseFontPx * 0.85)}px !important; }
+        .bill-content .doctor-details-inline p { margin: 0 !important; padding: 0 !important; }
+        .bill-content .doctor-details-inline * { font-size: inherit !important; }
 
         /* Footer */
         .bill-content.pdf-clone .footer-section { font-size: ${Math.round(rxBaseFontPx * 0.75)}px !important; }
@@ -1281,7 +1284,15 @@ function CheckupDetail() {
                           <img src={settings.checkupPdf.eSign} alt="Signature" className="esign-img" style={{ height: 'clamp(30px, 6vw, 50px)', objectFit: 'contain', marginBottom: '0.15rem', display: 'block', marginLeft: 'auto', marginRight: 'auto' }} />
                         )}
                         <div className="sig-line" style={{ borderTop: '1px solid #64748b', width: 'clamp(80px, 15vw, 120px)', marginBottom: '0.25rem', marginLeft: 'auto', marginRight: 'auto' }} />
-                        <p style={{ fontSize: 'clamp(0.55rem, 1.4vw, 0.65rem)', marginBottom: 0 }}>Signature</p>
+                        {settings?.checkupPdf?.doctorDetails ? (
+                          <div
+                            dangerouslySetInnerHTML={{ __html: settings.checkupPdf.doctorDetails }}
+                            style={{ fontSize: 'clamp(0.55rem, 1.4vw, 0.65rem)', lineHeight: 1.3, marginBottom: 0 }}
+                            className="doctor-details-inline"
+                          />
+                        ) : (
+                          <p style={{ fontSize: 'clamp(0.55rem, 1.4vw, 0.65rem)', marginBottom: 0 }}>Signature</p>
+                        )}
                       </div>
                     </div>
                   </>,

--- a/src/pages/tabs/LabResultsSettingsTab.jsx
+++ b/src/pages/tabs/LabResultsSettingsTab.jsx
@@ -1,11 +1,12 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { Row, Col, Card, Form, Badge } from 'react-bootstrap'
-import { FaPlus, FaTrash, FaFilePdf, FaStethoscope, FaVial, FaChevronDown, FaChevronRight, FaEdit, FaSave, FaTimes, FaAddressCard, FaSignature } from 'react-icons/fa'
+import { FaPlus, FaTrash, FaFilePdf, FaStethoscope, FaVial, FaChevronDown, FaChevronRight, FaEdit, FaSave, FaTimes, FaAddressCard, FaSignature, FaUserMd } from 'react-icons/fa'
 import { updateSettings } from '../../store/settingsSlice'
 import { useSettings } from '../../hooks/useSettings'
 import { useNotification } from '../../context'
 import LoadingSpinner from '../../components/common/LoadingSpinner'
+import RichTextEditor from '../../components/ui/RichTextEditor'
 
 function CheckupSettingsTab() {
   const dispatch = useDispatch()
@@ -847,6 +848,24 @@ function CheckupSettingsTab() {
                 </button>
               )}
             </div>
+          </Card.Body>
+        </Card>
+      </Col>
+
+      {/* Doctor Details */}
+      <Col xs={12}>
+        <Card className="shadow-sm border-0">
+          <Card.Body className="py-2 px-3">
+            <small className="fw-bold text-muted d-block mb-2"><FaUserMd className="me-2" style={{ fontSize: '0.7rem' }} />DOCTOR DETAILS</small>
+            <Form.Text className="text-muted d-block mb-2" style={{ fontSize: '0.65rem' }}>
+              Shown below the signature line on prescriptions. Supports bold, italic, font size, etc.
+            </Form.Text>
+            <RichTextEditor
+              value={settings?.checkupPdf?.doctorDetails || ''}
+              onChange={(html) => handleUpdate({ checkupPdf: { doctorDetails: html } })}
+              placeholder="e.g. Dr. John Smith&#10;MBBS, MD"
+              height="100px"
+            />
           </Card.Body>
         </Card>
       </Col>


### PR DESCRIPTION
## Summary
- Adds a `doctorDetails` rich text field to `checkupPdf` settings (bold, italic, size, alignment, etc.)
- Replaces the plain "Signature" label on prescriptions with the formatted doctor details HTML when set
- Falls back to "Signature" if no doctor details are configured
- Adds Doctor Details card in Lab Results settings tab using the existing RichTextEditor component

## Test plan
- [ ] Go to Settings → Lab Results → Doctor Details card, enter name + qualification with formatting (e.g. bold name, italic qualification)
- [ ] Open a checkup prescription tab — signature area should show the formatted details instead of "Signature"
- [ ] Generate a PDF and confirm doctor details render tightly with correct font size
- [ ] Leave Doctor Details blank — confirm prescription falls back to plain "Signature"