### PR TITLE
fix: restrict RichTextEditor toolbar per context, fix doctorDetails PDF rendering

### DIFF
--- a/src/components/ui/RichTextEditor.jsx
+++ b/src/components/ui/RichTextEditor.jsx
@@ -17,6 +17,25 @@ import { Form } from 'react-bootstrap'
  * - Clean formatting button
  */
 
+const FULL_TOOLBAR = [
+  [{ 'header': [1, 2, 3, false] }],
+  ['bold', 'italic', 'underline', 'strike'],
+  [{ 'list': 'ordered' }, { 'list': 'bullet' }],
+  [{ 'align': [] }],
+  ['link'],
+  ['blockquote', 'code-block'],
+  ['clean']
+]
+
+const FULL_FORMATS = [
+  'header',
+  'bold', 'italic', 'underline', 'strike',
+  'list',
+  'align',
+  'link',
+  'blockquote', 'code-block'
+]
+
 const RichTextEditor = ({
   value,
   onChange,
@@ -25,34 +44,15 @@ const RichTextEditor = ({
   label,
   required = false,
   height = '200px',
-  id
+  id,
+  toolbar = FULL_TOOLBAR,
+  formats = FULL_FORMATS,
 }) => {
   const editorRef = useRef(null)
   const quillRef = useRef(null)
   const isUpdating = useRef(false)
 
-  // Custom toolbar configuration
-  const modules = useMemo(() => ({
-    toolbar: [
-      [{ 'header': [1, 2, 3, false] }],
-      ['bold', 'italic', 'underline', 'strike'],
-      [{ 'list': 'ordered'}, { 'list': 'bullet' }],
-      [{ 'align': [] }],
-      ['link'],
-      ['blockquote', 'code-block'],
-      ['clean']
-    ],
-  }), [])
-
-  // Formats allowed in the editor
-  const formats = [
-    'header',
-    'bold', 'italic', 'underline', 'strike',
-    'list',
-    'align',
-    'link',
-    'blockquote', 'code-block'
-  ]
+  const modules = useMemo(() => ({ toolbar }), [])
 
   // Initialize Quill only once
   useEffect(() => {
@@ -60,7 +60,7 @@ const RichTextEditor = ({
       quillRef.current = new Quill(editorRef.current, {
         theme: 'snow',
         modules,
-        formats,
+        formats,  // uses prop
         placeholder
       })
 

--- a/src/pages/CheckupDetail.jsx
+++ b/src/pages/CheckupDetail.jsx
@@ -482,6 +482,7 @@ function CheckupDetail() {
         .bill-content.pdf-clone .date-signature-row p { font-size: ${Math.round(rxBaseFontPx * 0.85)}px !important; }
         .bill-content.pdf-clone .esign-img { height: ${Math.round(rxBaseFontPx * 3.5)}px !important; }
         .bill-content.pdf-clone .doctor-details-inline { font-size: ${Math.round(rxBaseFontPx * 0.85)}px !important; }
+        .bill-content .doctor-details-inline { padding: 0 !important; min-height: 0 !important; }
         .bill-content .doctor-details-inline p { margin: 0 !important; padding: 0 !important; }
         .bill-content .doctor-details-inline * { font-size: inherit !important; }
 
@@ -1287,8 +1288,8 @@ function CheckupDetail() {
                         {settings?.checkupPdf?.doctorDetails ? (
                           <div
                             dangerouslySetInnerHTML={{ __html: settings.checkupPdf.doctorDetails }}
-                            style={{ fontSize: 'clamp(0.55rem, 1.4vw, 0.65rem)', lineHeight: 1.3, marginBottom: 0 }}
-                            className="doctor-details-inline"
+                            style={{ fontSize: 'clamp(0.55rem, 1.4vw, 0.65rem)', lineHeight: 1.3, marginBottom: 0, padding: 0, minHeight: 0 }}
+                            className="ql-editor doctor-details-inline"
                           />
                         ) : (
                           <p style={{ fontSize: 'clamp(0.55rem, 1.4vw, 0.65rem)', marginBottom: 0 }}>Signature</p>

--- a/src/pages/tabs/LabResultsSettingsTab.jsx
+++ b/src/pages/tabs/LabResultsSettingsTab.jsx
@@ -863,8 +863,10 @@ function CheckupSettingsTab() {
             <RichTextEditor
               value={settings?.checkupPdf?.doctorDetails || ''}
               onChange={(html) => handleUpdate({ checkupPdf: { doctorDetails: html } })}
-              placeholder="e.g. Dr. John Smith&#10;MBBS, MD"
+              placeholder="e.g. Dr. John Smith, MBBS, MD"
               height="100px"
+              toolbar={[['bold', 'italic', 'underline'], [{ 'align': [] }], ['clean']]}
+              formats={['bold', 'italic', 'underline', 'align']}
             />
           </Card.Body>
         </Card>


### PR DESCRIPTION
## Summary
- Added `toolbar` and `formats` props to `RichTextEditor` so each usage context can restrict the toolbar (defaults unchanged — no existing usage breaks)
- `doctorDetails` editor in settings now uses a minimal toolbar (Bold / Italic / Underline / Align / Clean only — no H1/H2/H3 that would render huge in the PDF footer)
- Prescription signature render div now uses `ql-editor` class so Quill's alignment CSS (`ql-align-center` etc.) applies correctly, with overrides to reset editor padding/min-height

## Test plan
- [ ] Settings → Lab Results → Doctor Details: confirm toolbar shows only Bold / Italic / Underline / Align / Clean
- [ ] Enter formatted doctor details (bold name, italic qualification), open a prescription — confirm it renders correctly sized and aligned in the signature area
- [ ] Confirm no H1/H2/H3 option is available in the Doctor Details editor
- [ ] Open any other richtext editor (e.g. checkup notes) — confirm full toolbar still present
- [ ] Generate a prescription PDF — doctor details should render tightly with correct font size