### PR TITLE
feat: ship consultant fee + consultation-only checkups to production

### DIFF
--- a/src/constants/defaultSettings.js
+++ b/src/constants/defaultSettings.js
@@ -313,6 +313,8 @@ export const DEFAULT_SETTINGS = {
     doctorDetails: '',
     defaultValidDays: 30,
     defaultDoctorFees: 0,
+    showConsultantFee: true,
+    consultantFeeLabel: 'Consultant Fee',
     appointmentNotify: {
       whatsapp: { enabled: false, number: '' },
       email: { enabled: false, address: '' },

--- a/src/pages/CheckupDetail.jsx
+++ b/src/pages/CheckupDetail.jsx
@@ -1036,9 +1036,9 @@ function CheckupDetail() {
                             </tr>
                           ) : null
                         })}
-                        {parseFloat(checkup.doctorFees) > 0 && (
+                        {settings?.checkupPdf?.showConsultantFee !== false && parseFloat(checkup.doctorFees) > 0 && (
                           <tr>
-                            <td style={{ padding: 'clamp(0.2rem, 0.8vw, 0.4rem) clamp(0.3rem, 1vw, 0.6rem)', border: 'none', textAlign: 'left' }}>Consultant Fee</td>
+                            <td style={{ padding: 'clamp(0.2rem, 0.8vw, 0.4rem) clamp(0.3rem, 1vw, 0.6rem)', border: 'none', textAlign: 'left', fontWeight: 'bold' }}>{settings?.checkupPdf?.consultantFeeLabel || 'Consultant Fee'}</td>
                             <td style={{ padding: 'clamp(0.2rem, 0.8vw, 0.4rem) clamp(0.3rem, 1vw, 0.6rem)', border: 'none', textAlign: 'right' }}>Rs. {parseFloat(checkup.doctorFees).toFixed(2)}</td>
                           </tr>
                         )}

--- a/src/pages/CheckupDetail.jsx
+++ b/src/pages/CheckupDetail.jsx
@@ -1036,6 +1036,12 @@ function CheckupDetail() {
                             </tr>
                           ) : null
                         })}
+                        {parseFloat(checkup.doctorFees) > 0 && (
+                          <tr>
+                            <td style={{ padding: 'clamp(0.2rem, 0.8vw, 0.4rem) clamp(0.3rem, 1vw, 0.6rem)', border: 'none', textAlign: 'left' }}>Consultant Fee</td>
+                            <td style={{ padding: 'clamp(0.2rem, 0.8vw, 0.4rem) clamp(0.3rem, 1vw, 0.6rem)', border: 'none', textAlign: 'right' }}>Rs. {parseFloat(checkup.doctorFees).toFixed(2)}</td>
+                          </tr>
+                        )}
                         <tr style={{ color: '#0891B2', fontWeight: 'bold', borderTop: '1px solid #0891B2' }}>
                           <td style={{ padding: 'clamp(0.35rem, 1vw, 0.6rem) clamp(0.3rem, 1vw, 0.6rem)', border: 'none', textAlign: 'left' }}>Total Amount</td>
                           <td style={{ padding: 'clamp(0.35rem, 1vw, 0.6rem) clamp(0.3rem, 1vw, 0.6rem)', border: 'none', textAlign: 'right' }}>Rs. {checkup.total.toFixed(2)}</td>

--- a/src/pages/CheckupForm.jsx
+++ b/src/pages/CheckupForm.jsx
@@ -208,7 +208,7 @@ function CheckupForm() {
       return
     }
 
-    if (isFieldRequired('checkups', 'tests', true) && formData.tests.length === 0) {
+    if (formData.ownTests && isFieldRequired('checkups', 'tests', true) && formData.tests.length === 0) {
       showError('Please select at least one test')
       return
     }

--- a/src/pages/tabs/LabResultsSettingsTab.jsx
+++ b/src/pages/tabs/LabResultsSettingsTab.jsx
@@ -675,6 +675,40 @@ function CheckupSettingsTab() {
                 </Form.Text>
               </Col>
             </Row>
+            <div style={{ borderTop: '1px solid #e2e8f0', margin: '6px 0' }} />
+            <Row className="align-items-end g-1">
+              <Col xs={12} md={3} className="mb-2 mb-md-0">
+                <Form.Check
+                  type="switch"
+                  id="showConsultantFee"
+                  label={<span style={{ fontSize: '0.72rem' }}>Show Consultant Fee on Invoice</span>}
+                  checked={settings?.checkupPdf?.showConsultantFee !== false}
+                  onChange={(e) => handleUpdate({ checkupPdf: { showConsultantFee: e.target.checked } })}
+                />
+              </Col>
+              <Col xs={6} md={3}>
+                <Form.Group>
+                  <Form.Label style={{ fontSize: '0.68rem', color: '#64748b' }}>Consultant Fee Label</Form.Label>
+                  <Form.Control
+                    size="sm"
+                    type="text"
+                    defaultValue={settings?.checkupPdf?.consultantFeeLabel || 'Consultant Fee'}
+                    onBlur={(e) => {
+                      const val = e.target.value.trim()
+                      if (val && val !== (settings?.checkupPdf?.consultantFeeLabel || 'Consultant Fee')) {
+                        handleUpdate({ checkupPdf: { consultantFeeLabel: val } })
+                      }
+                    }}
+                    style={{ fontSize: '0.78rem' }}
+                  />
+                </Form.Group>
+              </Col>
+              <Col xs={6} md={6}>
+                <Form.Text className="text-muted" style={{ fontSize: '0.6rem' }}>
+                  Label for the doctor/consultant fee line on the invoice. Only shows when a fee is charged.
+                </Form.Text>
+              </Col>
+            </Row>
           </Card.Body>
         </Card>
       </Col>


### PR DESCRIPTION
Promotes the consultant-fee feature from `staging` to `main` (production).

## What ships
- **feat:** add consultant fee line item to invoice (`060a72b`)
- **feat:** make consultant fee on invoice configurable — label + visibility via Settings (`6964ac2`)
- **fix:** allow checkup creation without tests when *Own Tests* is off (`98d43f0`)

## Files
- `src/pages/CheckupDetail.jsx` — Consultant Fee line on invoice/PDF (bold, settings-driven)
- `src/pages/CheckupForm.jsx` — test requirement gated on `ownTests`
- `src/constants/defaultSettings.js` — `showConsultantFee`, `consultantFeeLabel`
- `src/pages/tabs/LabResultsSettingsTab.jsx` — Settings UI controls

## Notes
- Merges cleanly — these commits only touch Checkup/settings files that `main` has not changed.
- Merging to `main` triggers the automated release pipeline (version bump, deploy, GitHub Release).